### PR TITLE
fixed some paths from .app to .archway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ FROM alpine:3.12
 
 COPY --from=go-builder /code/build/archwayd /usr/bin/archwayd
 
-WORKDIR /root/.app
+WORKDIR /root/.archway
 
 # rest server
 EXPOSE 1317

--- a/contrib/localnet/localnet.sh
+++ b/contrib/localnet/localnet.sh
@@ -4,8 +4,8 @@
 
 set -e
 
-echo clearing /root/.app
-rm -rf /root/.app
+echo clearing /root/.archway
+rm -rf /root/.archway
 echo initting new chain
 # init config files
 archwayd init archwayd-id --chain-id localnet
@@ -27,7 +27,7 @@ archwayd collect-gentxs
 # verify genesis file is fine
 archwayd validate-genesis
 echo changing network settings
-sed -i 's/127.0.0.1/0.0.0.0/g' /root/.app/config/config.toml
+sed -i 's/127.0.0.1/0.0.0.0/g' /root/.archway/config/config.toml
 
 echo test account address: "$addr"
 echo test account private key: "$(yes | archwayd keys export fd --unsafe --unarmored-hex --keyring-backend=test)"


### PR DESCRIPTION
It could not load `config.toml` file giving the following error:

```bash
node_1  | sed: /root/.app/config/config.toml: No such file or directory
```

