### PR TITLE
hotfix: use appCodec and remove panic

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -290,7 +290,7 @@ func New(logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bool,
 	scopedTransferKeeper := app.capabilityKeeper.ScopeToModule(ibctransfertypes.ModuleName)
 	scopedWasmKeeper := app.capabilityKeeper.ScopeToModule(wasm.ModuleName)
 
-	app.gastrackingKeeper = gastracker.NewGasTrackingKeeper(keys[gastracker.StoreKey])
+	app.gastrackingKeeper = gastracker.NewGasTrackingKeeper(keys[gastracker.StoreKey], app.appCodec)
 
 	// add keepers
 	app.accountKeeper = authkeeper.NewAccountKeeper(

--- a/x/gastracker/module.go
+++ b/x/gastracker/module.go
@@ -59,11 +59,11 @@ func (a AppModule) RegisterGRPCGatewayRoutes(context client.Context, mux *runtim
 }
 
 func (a AppModule) GetTxCmd() *cobra.Command {
-	panic("implement me")
+	return nil
 }
 
 func (a AppModule) GetQueryCmd() *cobra.Command {
-	panic("implement me")
+	return nil
 }
 
 func (a AppModule) InitGenesis(context sdk.Context, marshaler codec.JSONMarshaler, message json.RawMessage) []abci.ValidatorUpdate {


### PR DESCRIPTION
Changes:
- Use appCodec instead of directly marshaling and unmarshalling 
- Tx and Query cmd cobra command now returns nil instead of panicking.