### PR TITLE
Put the `tx bank send` command back

### DIFF
--- a/cmd/archwayd/root.go
+++ b/cmd/archwayd/root.go
@@ -165,12 +165,13 @@ func txCommand() *cobra.Command {
 	var cmdsToRemove []*cobra.Command
 
 	for _, cmd := range cmd.Commands() {
-		if cmd.Use == authtypes.ModuleName || cmd.Use == banktypes.ModuleName {
+		// if cmd.Use == authtypes.ModuleName || cmd.Use == banktypes.ModuleName {
+		if cmd.Use == authtypes.ModuleName {
 			cmdsToRemove = append(cmdsToRemove, cmd)
 		}
 	}
 
-	// cmd.RemoveCommand(cmdsToRemove...)
+	cmd.RemoveCommand(cmdsToRemove...)
 	cmd.PersistentFlags().String(flags.FlagChainID, "", "The network chain ID")
 
 	return cmd


### PR DESCRIPTION
We need this fix to make it compatible with the `faucet`.