### PR TITLE
Fix security issue with base Alpine Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,6 @@ EXPOSE 26656
 # tendermint rpc
 EXPOSE 26657
 
-CMD ["/usr/bin/archwayd", "version"]
+ENTRYPOINT [ "/usr/bin/archwayd" ]
+
+CMD [ "version" ]


### PR DESCRIPTION
Running an image scan on the archwayd image detected a security vulnerability:

```
$ docker scan archway/archwayd:latest

Testing archway/archwayd:latest...

✗ High severity vulnerability found in busybox/busybox
  Description: Improper Handling of Exceptional Conditions
  Info: https://snyk.io/vuln/SNYK-ALPINE312-BUSYBOX-1089799
  Introduced through: busybox/busybox@1.31.1-r21, alpine-baselayout/alpine-baselayout@3.2.0-r7, busybox/ssl_client@1.31.1-r21
  From: busybox/busybox@1.31.1-r21
  From: alpine-baselayout/alpine-baselayout@3.2.0-r7 > busybox/busybox@1.31.1-r21
  From: busybox/ssl_client@1.31.1-r21
  Fixed in: 1.32.1-r4



Organization:      aelesbao-9mc
Package manager:   apk
Project name:      docker-image|archway/archwayd
Docker image:      archway/archwayd:latest
Platform:          linux/amd64
Base image:        alpine:3.12.9
Licenses:          enabled

Tested 14 dependencies for known issues, found 1 issue.

Base Image     Vulnerabilities  Severity
alpine:3.12.9  1                0 critical, 1 high, 0 medium, 0 low

Recommendations for base image upgrade:

Minor upgrades
Base Image     Vulnerabilities  Severity
alpine:3.13.7  0                0 critical, 0 high, 0 medium, 0 low
```

I'm also changing the image entrypoint to the archwayd binary so it's more intuitive to the user to run commands in the image without repeating `archwayd` many times in the command line:

```bash
docker run archwaynetwork/archwayd [command]
```