### PR TITLE
Run `help` instead of `version` as default command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ EXPOSE 26657
 
 ENTRYPOINT [ "/usr/bin/archwayd" ]
 
-CMD [ "version" ]
+CMD [ "help" ]


### PR DESCRIPTION
When running the Docker image directly from the cli, users get confused with the output of the `version` command. It's better that the image shows the `help` content instead.