### PR TITLE
Automatically tag Docker images for `augusta`

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -52,6 +52,7 @@ jobs:
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
             type=sha,priority=700
             type=raw,value=titus,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+            type=raw,value=augusta,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
             type=raw,value=constantine,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=edge,priority=100
           labels: |


### PR DESCRIPTION
The images for augusta will use the same rules as titus' images.