### PR TITLE
Update GasConsumed decimals value

### DIFF
--- a/x/gastracker/abci.go
+++ b/x/gastracker/abci.go
@@ -39,7 +39,7 @@ func EmitContractRewardCalculationEvent(context sdk.Context, contractAddress str
 
 	return context.EventManager().EmitTypedEvent(&gstTypes.ContractRewardCalculationEvent{
 		ContractAddress:  contractAddress,
-		GasConsumed:      gasConsumed.BigInt().Uint64(),
+		GasConsumed:      gasConsumed.RoundInt().Uint64(),
 		InflationRewards: &inflationReward,
 		ContractRewards:  rewards,
 		Metadata:         metadata,


### PR DESCRIPTION
Method BigInt currently returning a value of: 6491055731293290496, because it uses 18 decimal, but the correct value should be: 402496, which is corrected by RoundInt.