### PR TITLE
Titus-1 testnet fix

### DIFF
--- a/ci/titus-1.yaml
+++ b/ci/titus-1.yaml
@@ -68,10 +68,10 @@ spec:
   moniker: archway
   persistence:
     autoResize:
-      enabled: true
+      enabled: false
       increment: 5G
       threshold: 80
-    size: 5G
+    size: 160G
   replicas: 2
   resources:
     restServer: {}


### PR DESCRIPTION
Storage resize policy changed from "auto" to "fixed" due to `starport.cloud` issue with PVC resize.