### PR TITLE
fix go version in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The core implementation of the Archway protocol leverages the [Cosmos SDK](https
 
 ## Install Golang
 
-Go 1.16 is required for Archway.
+Go 1.17 is required for Archway.
 
 If you haven't already, download and install Go. See the official [go.dev documentation](https://golang.org/doc/install). Make sure your `GOBIN` and `GOPATH` are setup.
 


### PR DESCRIPTION
It's not possible to build project with go 1.16 version, at least 1.17 is required.