### PR TITLE
do not embed keeper interface into keeper struct

### DIFF
--- a/x/gastracker/keeper/keeper.go
+++ b/x/gastracker/keeper/keeper.go
@@ -52,7 +52,6 @@ type GasTrackingKeeper interface {
 }
 
 type Keeper struct {
-	GasTrackingKeeper
 	key              sdk.StoreKey
 	appCodec         codec.Codec
 	paramSpace       gastracker.Subspace


### PR DESCRIPTION
- Embedding keeper interface into struct cause interface to be unenforceable at compile time which results in runtime error