### PR TITLE
change: improve TX tracking

### DIFF
--- a/x/gastracker/ante/ante.go
+++ b/x/gastracker/ante/ante.go
@@ -8,7 +8,7 @@ import (
 
 type GasTrackingKeeper interface {
 	GetParams(ctx sdk.Context) gastracker.Params
-	TrackNewTx(ctx sdk.Context, rewardCoins []sdk.DecCoin, gas uint64) error
+	TrackNewTx(ctx sdk.Context, rewardCoins []sdk.DecCoin, gas uint64)
 }
 
 type TxGasTrackingDecorator struct {
@@ -37,10 +37,7 @@ func (t TxGasTrackingDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate 
 		rewardCoins[i] = reward
 	}
 
-	err = t.gasTrackingKeeper.TrackNewTx(ctx, rewardCoins, feeTx.GetGas())
-	if err != nil {
-		return ctx, err
-	}
+	t.gasTrackingKeeper.TrackNewTx(ctx, rewardCoins, feeTx.GetGas())
 
 	return next(ctx, tx, simulate)
 }

--- a/x/gastracker/ante/ante_test.go
+++ b/x/gastracker/ante/ante_test.go
@@ -1,31 +1,11 @@
 package ante
 
 import (
-	"os"
-	"testing"
-	"time"
-
-	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
-	wasmTypes "github.com/CosmWasm/wasmd/x/wasm/types"
-	"github.com/cosmos/cosmos-sdk/simapp"
-	"github.com/cosmos/cosmos-sdk/store"
+	"github.com/archway-network/archway/x/gastracker/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	tmLog "github.com/tendermint/tendermint/libs/log"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
-	db "github.com/tendermint/tm-db"
-
-	"github.com/archway-network/archway/x/gastracker"
-	gstTypes "github.com/archway-network/archway/x/gastracker"
-	"github.com/archway-network/archway/x/gastracker/keeper"
-)
-
-// NOTE: this is needed to allow the keeper to set BlockGasTracking
-var (
-	storeKey = sdk.NewKVStoreKey(gastracker.StoreKey)
+	"testing"
 )
 
 type dummyTx struct {
@@ -73,7 +53,7 @@ func dummyNextAnteHandler(_ sdk.Context, _ sdk.Tx, _ bool) (newCtx sdk.Context, 
 }
 
 func TestGasTrackingAnteHandler(t *testing.T) {
-	ctx, keeper := CreateTestKeeperAndContext(t, sdk.AccAddress{})
+	ctx, keeper := testutil.CreateTestKeeperAndContext(t, sdk.AccAddress{})
 
 	testTxGasTrackingDecorator := NewTxGasTrackingDecorator(keeper)
 
@@ -137,77 +117,3 @@ func TestGasTrackingAnteHandler(t *testing.T) {
 	assert.Equal(t, testTx.Gas, currentBlockTrackingInfo.TxTrackingInfos[1].MaxGasAllowed, "MaxGasAllowed must match the Gas field of tx")
 	assert.Equal(t, expectedDecCoins, currentBlockTrackingInfo.TxTrackingInfos[1].MaxContractRewards, "MaxContractReward must be half of the tx fees")
 }
-
-// TODO: this is shared test util, that is copied
-// from /keeper/keeper_test, refactor
-func createTestBaseKeeperAndContext(t *testing.T, contractAdmin sdk.AccAddress) (sdk.Context, keeper.Keeper) {
-	encodingConfig := simapp.MakeTestEncodingConfig()
-	appCodec := encodingConfig.Marshaler
-
-	memDB := db.NewMemDB()
-	ms := store.NewCommitMultiStore(memDB)
-
-	mkey := sdk.NewKVStoreKey("test")
-	tkey := sdk.NewTransientStoreKey("transient_test")
-	tstoreKey := sdk.NewTransientStoreKey(gastracker.TStoreKey)
-
-	ms.MountStoreWithDB(mkey, sdk.StoreTypeIAVL, memDB)
-	ms.MountStoreWithDB(tkey, sdk.StoreTypeIAVL, memDB)
-	ms.MountStoreWithDB(storeKey, sdk.StoreTypeIAVL, memDB)
-	ms.MountStoreWithDB(tstoreKey, sdk.StoreTypeTransient, memDB)
-
-	err := ms.LoadLatestVersion()
-	require.NoError(t, err, "Loading latest version should not fail")
-
-	pkeeper := paramskeeper.NewKeeper(appCodec, encodingConfig.Amino, mkey, tkey)
-	subspace := pkeeper.Subspace(gstTypes.ModuleName)
-
-	keeper := keeper.NewGasTrackingKeeper(
-		storeKey,
-		appCodec,
-		subspace,
-		NewTestContractInfoView(contractAdmin.String()),
-		wasmkeeper.NewDefaultWasmGasRegister(),
-		nil,
-	)
-
-	ctx := sdk.NewContext(ms, tmproto.Header{
-		Height: 10000,
-		Time:   time.Date(2020, time.April, 22, 12, 0, 0, 0, time.UTC),
-	}, false, tmLog.NewTMLogger(os.Stdout))
-
-	params := gstTypes.DefaultParams()
-	subspace.SetParamSet(ctx, &params)
-	return ctx, keeper
-}
-
-func CreateTestKeeperAndContext(t *testing.T, contractAdmin sdk.AccAddress) (sdk.Context, keeper.Keeper) {
-	return createTestBaseKeeperAndContext(t, contractAdmin)
-}
-
-type TestContractInfoView struct {
-	keeper.ContractInfoView
-	adminMap     map[string]string
-	defaultAdmin string
-}
-
-func NewTestContractInfoView(defaultAdmin string) *TestContractInfoView {
-	return &TestContractInfoView{
-		adminMap:     make(map[string]string),
-		defaultAdmin: defaultAdmin,
-	}
-}
-
-func (t *TestContractInfoView) GetContractInfo(_ sdk.Context, contractAddress sdk.AccAddress) *wasmTypes.ContractInfo {
-	if admin, ok := t.adminMap[contractAddress.String()]; ok {
-		return &wasmTypes.ContractInfo{Admin: admin}
-	} else {
-		return &wasmTypes.ContractInfo{Admin: t.defaultAdmin}
-	}
-}
-
-func (t *TestContractInfoView) AddContractToAdminMapping(contractAddress string, admin string) {
-	t.adminMap[contractAddress] = admin
-}
-
-var _ keeper.ContractInfoView = &TestContractInfoView{}

--- a/x/gastracker/ante/ante_test.go
+++ b/x/gastracker/ante/ante_test.go
@@ -88,7 +88,6 @@ func TestGasTrackingAnteHandler(t *testing.T) {
 	)
 
 	currentBlockTrackingInfo := keeper.GetCurrentBlockTracking(ctx)
-	assert.NoError(t, err, "Current block tracking info should exists")
 
 	assert.Equal(t, 1, len(currentBlockTrackingInfo.TxTrackingInfos), "Only 1 txtracking info should be there")
 	assert.Equal(t, testTx.Gas, currentBlockTrackingInfo.TxTrackingInfos[0].MaxGasAllowed, "MaxGasAllowed must match the Gas field of tx")

--- a/x/gastracker/ante/ante_test.go
+++ b/x/gastracker/ante/ante_test.go
@@ -98,16 +98,7 @@ func TestGasTrackingAnteHandler(t *testing.T) {
 		expectedDecCoins[i] = sdk.NewDecCoinFromCoin(sdk.NewCoin(coin.Denom, coin.Amount.QuoRaw(2)))
 	}
 
-	_, err = testTxGasTrackingDecorator.AnteHandle(ctx, testTx, false, dummyNextAnteHandler)
-	assert.EqualError(
-		t,
-		err,
-		gstTypes.ErrBlockTrackingDataNotFound.Error(),
-		"Gastracking ante handler should return expected error",
-	)
-
-	err = keeper.TrackNewBlock(ctx)
-	assert.NoError(t, err, "New block gas tracking should succeed")
+	keeper.TrackNewBlock(ctx)
 
 	_, err = testTxGasTrackingDecorator.AnteHandle(ctx, testTx, false, dummyNextAnteHandler)
 	assert.NoError(
@@ -116,7 +107,7 @@ func TestGasTrackingAnteHandler(t *testing.T) {
 		"Gastracking ante handler should not return an error",
 	)
 
-	currentBlockTrackingInfo, err := keeper.GetCurrentBlockTracking(ctx)
+	currentBlockTrackingInfo := keeper.GetCurrentBlockTracking(ctx)
 	assert.NoError(t, err, "Current block tracking info should exists")
 
 	assert.Equal(t, 1, len(currentBlockTrackingInfo.TxTrackingInfos), "Only 1 txtracking info should be there")
@@ -140,8 +131,7 @@ func TestGasTrackingAnteHandler(t *testing.T) {
 		"Gastracking ante handler should not return an error",
 	)
 
-	currentBlockTrackingInfo, err = keeper.GetCurrentBlockTracking(ctx)
-	assert.NoError(t, err, "Current block tracking info should exists")
+	currentBlockTrackingInfo = keeper.GetCurrentBlockTracking(ctx)
 
 	assert.Equal(t, 2, len(currentBlockTrackingInfo.TxTrackingInfos), "Only 1 txtracking info should be there")
 	assert.Equal(t, testTx.Gas, currentBlockTrackingInfo.TxTrackingInfos[1].MaxGasAllowed, "MaxGasAllowed must match the Gas field of tx")

--- a/x/gastracker/keeper/grpc_query.go
+++ b/x/gastracker/keeper/grpc_query.go
@@ -47,10 +47,7 @@ func (g *queryServer) BlockGasTracking(ctx context.Context, request *gstTypes.Qu
 		return nil, status.Error(codes.InvalidArgument, "empty request")
 	}
 
-	blockGasTracking, err := g.keeper.GetCurrentBlockTracking(sdk.UnwrapSDKContext(ctx))
-	if err != nil {
-		return nil, err
-	}
+	blockGasTracking := g.keeper.GetCurrentBlockTracking(sdk.UnwrapSDKContext(ctx))
 
 	return &gstTypes.QueryBlockGasTrackingResponse{
 		BlockGasTracking: &blockGasTracking,

--- a/x/gastracker/keeper/keeper.go
+++ b/x/gastracker/keeper/keeper.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmTypes "github.com/CosmWasm/wasmd/x/wasm/types"
-	"github.com/cosmos/cosmos-sdk/store/prefix"
-	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
-	"log"
-
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	paramsTypes "github.com/cosmos/cosmos-sdk/x/params/types"
 
 	gastracker "github.com/archway-network/archway/x/gastracker"
@@ -187,7 +185,6 @@ func (k Keeper) GetCurrentBlockTracking(ctx sdk.Context) gastracker.BlockGasTrac
 	for ; iter.Valid(); iter.Next() {
 		v := gastracker.TransactionTracking{}
 		k.cdc.MustUnmarshal(iter.Value(), &v)
-		log.Printf("%s", &v)
 		currentBlockTracking.TxTrackingInfos = append(currentBlockTracking.TxTrackingInfos, v)
 	}
 

--- a/x/gastracker/keeper/keeper.go
+++ b/x/gastracker/keeper/keeper.go
@@ -206,6 +206,21 @@ func (k Keeper) TrackNewTx(ctx sdk.Context, fee []sdk.DecCoin, gasLimit uint64) 
 	return nil
 }
 
+// GetAndIncreaseTxIdentifier gets the current Tx identifier.
+// Then increases the current tx identifier by 1.
+// Assumes there is already a valid value saved in the store.
+func (k Keeper) GetAndIncreaseTxIdentifier(ctx sdk.Context) uint64 {
+	store := prefix.NewStore(ctx.KVStore(k.key), gastracker.PrefixGasTrackingTxIdentifier)
+	value := sdk.BigEndianToUint64(store.Get(gastracker.KeyTxIdentifier))
+	store.Set(gastracker.KeyTxIdentifier, sdk.Uint64ToBigEndian(value+1))
+	return value
+}
+
+// ResetTxIdentifier resets the current Tx identifier to 0.
+func (k Keeper) ResetTxIdentifier(ctx sdk.Context) {
+	prefix.NewStore(ctx.KVStore(k.key), gastracker.PrefixGasTrackingTxIdentifier).Set(gastracker.KeyTxIdentifier, sdk.Uint64ToBigEndian(0))
+}
+
 func (k Keeper) TrackContractGasUsage(ctx sdk.Context, contractAddress sdk.AccAddress, originalGas wasmTypes.GasConsumptionInfo, operation gastracker.ContractOperation) error {
 
 	gstKvStore := ctx.KVStore(k.key)

--- a/x/gastracker/keeper/keeper.go
+++ b/x/gastracker/keeper/keeper.go
@@ -25,13 +25,13 @@ type MintKeeper interface {
 }
 
 type Keeper struct {
+	WasmGasRegister wasmkeeper.GasRegister // can safely be exported since it's readonly.
+
 	key              sdk.StoreKey
 	cdc              codec.Codec
 	paramSpace       gastracker.Subspace
 	contractInfoView ContractInfoView
-	wasmGasRegister  wasmkeeper.GasRegister
-
-	mintKeeper MintKeeper
+	mintKeeper       MintKeeper
 }
 
 func NewGasTrackingKeeper(
@@ -50,7 +50,7 @@ func NewGasTrackingKeeper(
 		cdc:              appCodec,
 		paramSpace:       paramSpace,
 		contractInfoView: contractInfoView,
-		wasmGasRegister:  gasRegister,
+		WasmGasRegister:  gasRegister,
 		mintKeeper:       mintKeeper,
 	}
 }

--- a/x/gastracker/keeper/keeper.go
+++ b/x/gastracker/keeper/keeper.go
@@ -211,6 +211,8 @@ func (k Keeper) TrackContractGasUsage(ctx sdk.Context, contractAddress sdk.AccAd
 
 	bytes := store.Get(key)
 	if bytes == nil {
+		// panicking here since TrackNewTx must always be called before
+		// we start appending operations to contracts.
 		panic(fmt.Errorf("no gas tracking found for tx"))
 	}
 	var transactionTracking gastracker.TransactionTracking

--- a/x/gastracker/keeper/keeper_contract_gas_processor.go
+++ b/x/gastracker/keeper/keeper_contract_gas_processor.go
@@ -66,7 +66,7 @@ func (k Keeper) IngestGasRecord(ctx types.Context, records []wasmTypes.ContractG
 
 		k.TrackContractGasUsage(ctx, contractAddress, wasmTypes.GasConsumptionInfo{
 			SDKGas: record.OriginalGas.SDKGas,
-			VMGas:  k.wasmGasRegister.FromWasmVMGas(record.OriginalGas.VMGas),
+			VMGas:  k.WasmGasRegister.FromWasmVMGas(record.OriginalGas.VMGas),
 		}, operation)
 	}
 

--- a/x/gastracker/keeper/keeper_contract_gas_processor.go
+++ b/x/gastracker/keeper/keeper_contract_gas_processor.go
@@ -64,12 +64,10 @@ func (k Keeper) IngestGasRecord(ctx types.Context, records []wasmTypes.ContractG
 			operation = gastracker.ContractOperation_CONTRACT_OPERATION_UNSPECIFIED
 		}
 
-		if err := k.TrackContractGasUsage(ctx, contractAddress, wasmTypes.GasConsumptionInfo{
+		k.TrackContractGasUsage(ctx, contractAddress, wasmTypes.GasConsumptionInfo{
 			SDKGas: record.OriginalGas.SDKGas,
 			VMGas:  k.wasmGasRegister.FromWasmVMGas(record.OriginalGas.VMGas),
-		}, operation); err != nil {
-			return err
-		}
+		}, operation)
 	}
 
 	return nil

--- a/x/gastracker/keeper/keeper_test.go
+++ b/x/gastracker/keeper/keeper_test.go
@@ -111,6 +111,13 @@ func CreateTestKeeperAndContext(t *testing.T, contractAdmin sdk.AccAddress) (sdk
 	return createTestBaseKeeperAndContext(t, contractAdmin)
 }
 
+func TestKeeper_GetAndIncreaseTxIdentifier_ResetTxIdentifier(t *testing.T) {
+	ctx, k := CreateTestKeeperAndContext(t, nil)
+	k.ResetTxIdentifier(ctx)
+	require.Equal(t, uint64(0), k.GetAndIncreaseTxIdentifier(ctx))
+	require.Equal(t, uint64(1), k.GetAndIncreaseTxIdentifier(ctx))
+}
+
 func TestKeeper_UpdateGetDappInflationaryRewards(t *testing.T) {
 	ctx, k := CreateTestKeeperAndContext(t, nil)
 	t.Run("success", func(t *testing.T) {

--- a/x/gastracker/keys.go
+++ b/x/gastracker/keys.go
@@ -29,6 +29,16 @@ const (
 
 var (
 	PrefixDappBlockInflationaryRewards = []byte{0x10}
+	// PrefixGasTrackingTxIdentifier maps the current transaction being tracked identifier.
+	// This value is reset every block. And increased each time keeper.Keeper.TrackNewTx is called.
+	PrefixGasTrackingTxIdentifier = []byte{0x11}
+	// PrefixGasTrackingTxTracking is the kvstore namespace that contains TransactionTracking objects
+	// of the current block.
+	PrefixGasTrackingTxTracking = []byte{0x13}
+
+	// KeyTxIdentifier is the constant key used to get the Tx identifier
+	// in the current block.
+	KeyTxIdentifier = []byte{0x0}
 )
 
 func GetPendingContractInstanceMetadataKey(address string) []byte {

--- a/x/gastracker/keys.go
+++ b/x/gastracker/keys.go
@@ -3,18 +3,14 @@ package gastracker
 const (
 	// ModuleName is the name of the contract module
 	ModuleName = "gastracker"
-
+	// ContractRewardCollector is the module holding rewards collected by dApps.
 	ContractRewardCollector = ModuleName
-
 	// StoreKey is the string store representation
 	StoreKey = ModuleName
-
 	// TStoreKey is the string transient store representation
 	TStoreKey = "transient_" + ModuleName
-
 	// QuerierRoute is the querier route for the wasm module
 	QuerierRoute = ModuleName
-
 	// RouterKey is the msg router key for the wasm module
 	RouterKey = ModuleName
 

--- a/x/gastracker/keys.go
+++ b/x/gastracker/keys.go
@@ -18,8 +18,6 @@ const (
 	// RouterKey is the msg router key for the wasm module
 	RouterKey = ModuleName
 
-	CurrentBlockTrackingKey = "current_blk"
-
 	PendingContractInstanceMetadataKeyPrefix = "p_c_inst_md"
 
 	ContractInstanceMetadataKeyPrefix = "c_inst_md"

--- a/x/gastracker/module/abci.go
+++ b/x/gastracker/module/abci.go
@@ -76,6 +76,8 @@ func resetBlockGasTracking(context sdk.Context, gasTrackingKeeper keeper.Keeper)
 	if err := gasTrackingKeeper.TrackNewBlock(context); err != nil {
 		panic(err)
 	}
+
+	gasTrackingKeeper.ResetTxIdentifier(context)
 	return lastBlockGasTracking
 }
 

--- a/x/gastracker/module/abci.go
+++ b/x/gastracker/module/abci.go
@@ -71,32 +71,11 @@ func commitPendingMetadata(context sdk.Context, gasTrackingKeeper keeper.Keeper)
 
 // resetBlockGasTracking resets the current status and returns the last blockGasTracking
 func resetBlockGasTracking(context sdk.Context, gasTrackingKeeper keeper.Keeper) gstTypes.BlockGasTracking {
-	lastBlockGasTracking := getCurrentBlockGasTracking(context, gasTrackingKeeper)
+	lastBlockGasTracking := gasTrackingKeeper.GetCurrentBlockTracking(context)
 
-	if err := gasTrackingKeeper.TrackNewBlock(context); err != nil {
-		panic(err)
-	}
+	gasTrackingKeeper.TrackNewBlock(context)
 
-	gasTrackingKeeper.ResetTxIdentifier(context)
 	return lastBlockGasTracking
-}
-
-// getCurrentBlockGasTracking returns the actual block gas tracking, panics if empty and block height is bigger than one.
-func getCurrentBlockGasTracking(context sdk.Context, gasTrackingKeeper keeper.Keeper) gstTypes.BlockGasTracking {
-	currentBlockTrackingInfo, err := gasTrackingKeeper.GetCurrentBlockTracking(context)
-	if err != nil {
-		switch err {
-		case gstTypes.ErrBlockTrackingDataNotFound:
-			// Only panic when there was a previous block
-			if context.BlockHeight() > 1 {
-				panic(err)
-			}
-		default:
-			panic(err)
-		}
-	}
-
-	return currentBlockTrackingInfo
 }
 
 // distributeRewards distributes the calculated rewards to all the contracts owners.

--- a/x/gastracker/module/abci_test.go
+++ b/x/gastracker/module/abci_test.go
@@ -2,7 +2,6 @@ package module
 
 import (
 	"fmt"
-	gastracker "github.com/archway-network/archway/x/gastracker"
 	gstTypes "github.com/archway-network/archway/x/gastracker"
 	"github.com/archway-network/archway/x/gastracker/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -19,11 +18,6 @@ const (
 	Log Behaviour = iota
 	Error
 	Panic
-)
-
-// NOTE: this is needed to allow the keeper to set BlockGasTracking
-var (
-	storeKey = sdk.NewKVStoreKey(gastracker.StoreKey)
 )
 
 type RewardTransferKeeperCallLogs struct {

--- a/x/gastracker/module/abci_test.go
+++ b/x/gastracker/module/abci_test.go
@@ -159,19 +159,13 @@ func TestABCIPanicBehaviour(t *testing.T) {
 
 	testRewardKeeper := &TestRewardTransferKeeper{B: Log}
 
-	ctx = ctx.WithBlockHeight(2)
-	require.PanicsWithError(t, gstTypes.ErrBlockTrackingDataNotFound.Error(), func() {
-		BeginBlock(ctx, types.RequestBeginBlock{}, keeper, testRewardKeeper)
-	}, "BeginBlock should panic")
-
 	ctx = ctx.WithBlockHeight(1)
 
 	BeginBlock(ctx, types.RequestBeginBlock{}, keeper, testRewardKeeper)
 	// We should not have made any call to reward keeper
 	require.Zero(t, testRewardKeeper.Logs, "No logs should be there as no need to make new calls")
 	// We would have overwritten the TrackNewBlock obj
-	blockGasTracking, err := keeper.GetCurrentBlockTracking(ctx)
-	require.NoError(t, err, "We should be able to get new block gas tracking")
+	blockGasTracking := keeper.GetCurrentBlockTracking(ctx)
 	require.Equal(t, gstTypes.BlockGasTracking{}, blockGasTracking, "We should have overwritten block gas tracking obj")
 }
 
@@ -351,11 +345,9 @@ func TestRewardCalculation(t *testing.T) {
 	require.Equal(t, 4, numberOfMetadataCommitted, "Number of metadata commits should match")
 
 	// Tracking new block with multiple tx tracking obj
-	err = keeper.TrackNewBlock(ctx)
+	keeper.TrackNewBlock(ctx)
 
-	require.NoError(t, err, "We should be able to track new block")
-
-	CreateTestBlockEntry(ctx, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
+	CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
 		{
 			MaxGasAllowed:      10,
 			MaxContractRewards: []sdk.DecCoin{firstTxMaxContractReward[0], firstTxMaxContractReward[1]},
@@ -506,11 +498,9 @@ func TestContractRewardsWithoutContractPremium(t *testing.T) {
 	require.Equal(t, 4, numberOfMetadataCommitted, "Number of metadata commits should match")
 
 	// Tracking new block with multiple tx tracking obj
-	err = keeper.TrackNewBlock(ctx)
+	keeper.TrackNewBlock(ctx)
 
-	require.NoError(t, err, "We should be able to track new block")
-
-	CreateTestBlockEntry(ctx, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
+	CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
 		{
 			MaxGasAllowed:      10,
 			MaxContractRewards: []sdk.DecCoin{firstTxMaxContractReward[0], firstTxMaxContractReward[1]},
@@ -658,11 +648,9 @@ func TestContractRewardsWithoutDappInflation(t *testing.T) {
 	require.Equal(t, 4, numberOfMetadataCommitted, "Number of metadata commits should match")
 
 	// Tracking new block with multiple tx tracking obj
-	err = keeper.TrackNewBlock(ctx)
+	keeper.TrackNewBlock(ctx)
 
-	require.NoError(t, err, "We should be able to track new block")
-
-	CreateTestBlockEntry(ctx, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
+	CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
 		{
 			MaxGasAllowed:      10,
 			MaxContractRewards: []sdk.DecCoin{firstTxMaxContractReward[0], firstTxMaxContractReward[1]},
@@ -808,11 +796,9 @@ func TestContractRewardsWithoutGasRebate(t *testing.T) {
 	require.Equal(t, 4, numberOfMetadataCommitted, "Number of metadata commits should match")
 
 	// Tracking new block with multiple tx tracking obj
-	err = keeper.TrackNewBlock(ctx)
+	keeper.TrackNewBlock(ctx)
 
-	require.NoError(t, err, "We should be able to track new block")
-
-	CreateTestBlockEntry(ctx, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
+	CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
 		{
 			MaxGasAllowed:      10,
 			MaxContractRewards: []sdk.DecCoin{firstTxMaxContractReward[0], firstTxMaxContractReward[1]},
@@ -951,11 +937,9 @@ func TestContractRewardWithoutGasRebateAndDappInflation(t *testing.T) {
 	require.Equal(t, 4, numberOfMetadataCommitted, "Number of metadata commits should match")
 
 	// Tracking new block with multiple tx tracking obj
-	err = keeper.TrackNewBlock(ctx)
+	keeper.TrackNewBlock(ctx)
 
-	require.NoError(t, err, "We should be able to track new block")
-
-	CreateTestBlockEntry(ctx, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
+	CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
 		{
 			MaxGasAllowed:      10,
 			MaxContractRewards: []sdk.DecCoin{firstTxMaxContractReward[0], firstTxMaxContractReward[1]},
@@ -1086,11 +1070,9 @@ func TestContractRewardsWithoutGasTracking(t *testing.T) {
 	require.Equal(t, 4, numberOfMetadataCommitted, "Number of metadata commits should match")
 
 	// Tracking new block with multiple tx tracking obj
-	err = keeper.TrackNewBlock(ctx)
+	keeper.TrackNewBlock(ctx)
 
-	require.NoError(t, err, "We should be able to track new block")
-
-	CreateTestBlockEntry(ctx, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
+	CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
 		{
 			MaxGasAllowed:      10,
 			MaxContractRewards: []sdk.DecCoin{firstTxMaxContractReward[0], firstTxMaxContractReward[1]},
@@ -1232,11 +1214,9 @@ func TestContractRewardsWithoutGasRebateToUser(t *testing.T) {
 	require.Equal(t, 4, numberOfMetadataCommitted, "Number of metadata commits should match")
 
 	// Tracking new block with multiple tx tracking obj
-	err = keeper.TrackNewBlock(ctx)
+	keeper.TrackNewBlock(ctx)
 
-	require.NoError(t, err, "We should be able to track new block")
-
-	CreateTestBlockEntry(ctx, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
+	CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
 		{
 			MaxGasAllowed:      10,
 			MaxContractRewards: []sdk.DecCoin{firstTxMaxContractReward[0], firstTxMaxContractReward[1]},
@@ -1350,13 +1330,18 @@ func CreateTestKeeperAndContext(t *testing.T, contractAdmin sdk.AccAddress) (sdk
 	return createTestBaseKeeperAndContext(t, contractAdmin)
 }
 
-func CreateTestBlockEntry(ctx sdk.Context, blockTracking gstTypes.BlockGasTracking) {
-	kvStore := ctx.KVStore(storeKey)
-	bz, err := simapp.MakeTestEncodingConfig().Marshaler.Marshal(&blockTracking)
-	if err != nil {
-		panic(err)
+func CreateTestBlockEntry(ctx sdk.Context, k keeper.Keeper, blockTracking gstTypes.BlockGasTracking) {
+	k.TrackNewBlock(ctx)
+	for _, tx := range blockTracking.TxTrackingInfos {
+		k.TrackNewTx(ctx, tx.MaxContractRewards, tx.MaxGasAllowed)
+		for _, op := range tx.ContractTrackingInfos {
+			addr, _ := sdk.AccAddressFromBech32(op.Address)
+			k.TrackContractGasUsage(ctx, addr, wasmTypes.GasConsumptionInfo{
+				VMGas:  op.OriginalVmGas,
+				SDKGas: op.OriginalSdkGas,
+			}, op.Operation)
+		}
 	}
-	kvStore.Set([]byte(gstTypes.CurrentBlockTrackingKey), bz)
 }
 
 type TestContractInfoView struct {

--- a/x/gastracker/module/abci_test.go
+++ b/x/gastracker/module/abci_test.go
@@ -2,30 +2,15 @@ package module
 
 import (
 	"fmt"
-	"math/rand"
-	"os"
-	"testing"
-	"time"
-
-	"github.com/cosmos/cosmos-sdk/simapp"
-	"github.com/cosmos/cosmos-sdk/store"
-
-	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
-	wasmTypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	gastracker "github.com/archway-network/archway/x/gastracker"
+	gstTypes "github.com/archway-network/archway/x/gastracker"
+	"github.com/archway-network/archway/x/gastracker/testutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authTypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	mintTypes "github.com/cosmos/cosmos-sdk/x/mint/types"
-	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/abci/types"
-	tmLog "github.com/tendermint/tendermint/libs/log"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
-
-	db "github.com/tendermint/tm-db"
-
-	gastracker "github.com/archway-network/archway/x/gastracker"
-	gstTypes "github.com/archway-network/archway/x/gastracker"
-	keeper "github.com/archway-network/archway/x/gastracker/keeper"
+	"testing"
 )
 
 type Behaviour int
@@ -150,7 +135,7 @@ func disableGasRebateToUser(params gstTypes.Params) gstTypes.Params {
 
 // Test the conditions under which BeginBlocker and EndBlocker should panic or not panic
 func TestABCIPanicBehaviour(t *testing.T) {
-	ctx, keeper := CreateTestKeeperAndContext(t, sdk.AccAddress{})
+	ctx, keeper := testutil.CreateTestKeeperAndContext(t, sdk.AccAddress{})
 
 	config := sdk.GetConfig()
 	config.SetBech32PrefixForAccount("archway", "archway")
@@ -175,12 +160,12 @@ func TestABCIContractMetadataCommit(t *testing.T) {
 
 	var spareAddress = make([]sdk.AccAddress, 10)
 	for i := 0; i < 10; i++ {
-		spareAddress[i] = GenerateRandomAccAddress()
+		spareAddress[i] = testutil.GenerateRandomAccAddress()
 	}
 
 	testRewardKeeper := &TestRewardTransferKeeper{B: Log}
 
-	ctx, keeper := createTestBaseKeeperAndContext(t, spareAddress[0])
+	ctx, keeper := testutil.CreateTestKeeperAndContext(t, spareAddress[0])
 
 	contractMetadatas := []gstTypes.ContractInstanceMetadata{
 		{
@@ -270,7 +255,7 @@ func TestRewardCalculation(t *testing.T) {
 
 	var spareAddress = make([]sdk.AccAddress, 10)
 	for i := 0; i < 10; i++ {
-		spareAddress[i] = GenerateRandomAccAddress()
+		spareAddress[i] = testutil.GenerateRandomAccAddress()
 	}
 
 	type expect struct {
@@ -295,7 +280,7 @@ func TestRewardCalculation(t *testing.T) {
 		},
 	}
 
-	ctx, keeper := createTestBaseKeeperAndContext(t, spareAddress[0])
+	ctx, keeper := testutil.CreateTestKeeperAndContext(t, spareAddress[0])
 	ctx = ctx.WithBlockGasMeter(sdk.NewGasMeter(200000))
 
 	keeper.SetParams(ctx, params)
@@ -347,7 +332,7 @@ func TestRewardCalculation(t *testing.T) {
 	// Tracking new block with multiple tx tracking obj
 	keeper.TrackNewBlock(ctx)
 
-	CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
+	testutil.CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
 		{
 			MaxGasAllowed:      10,
 			MaxContractRewards: []sdk.DecCoin{firstTxMaxContractReward[0], firstTxMaxContractReward[1]},
@@ -424,7 +409,7 @@ func TestContractRewardsWithoutContractPremium(t *testing.T) {
 
 	var spareAddress = make([]sdk.AccAddress, 10)
 	for i := 0; i < 10; i++ {
-		spareAddress[i] = GenerateRandomAccAddress()
+		spareAddress[i] = testutil.GenerateRandomAccAddress()
 	}
 
 	type expect struct {
@@ -449,7 +434,7 @@ func TestContractRewardsWithoutContractPremium(t *testing.T) {
 		},
 	}
 
-	ctx, keeper := createTestBaseKeeperAndContext(t, spareAddress[0])
+	ctx, keeper := testutil.CreateTestKeeperAndContext(t, spareAddress[0])
 	ctx = ctx.WithBlockGasMeter(sdk.NewGasMeter(200000))
 	keeper.SetParams(ctx, params)
 
@@ -500,7 +485,7 @@ func TestContractRewardsWithoutContractPremium(t *testing.T) {
 	// Tracking new block with multiple tx tracking obj
 	keeper.TrackNewBlock(ctx)
 
-	CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
+	testutil.CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
 		{
 			MaxGasAllowed:      10,
 			MaxContractRewards: []sdk.DecCoin{firstTxMaxContractReward[0], firstTxMaxContractReward[1]},
@@ -573,7 +558,7 @@ func TestContractRewardsWithoutDappInflation(t *testing.T) {
 
 	var spareAddress = make([]sdk.AccAddress, 10)
 	for i := 0; i < 10; i++ {
-		spareAddress[i] = GenerateRandomAccAddress()
+		spareAddress[i] = testutil.GenerateRandomAccAddress()
 	}
 
 	type expect struct {
@@ -598,7 +583,7 @@ func TestContractRewardsWithoutDappInflation(t *testing.T) {
 		},
 	}
 
-	ctx, keeper := createTestBaseKeeperAndContext(t, spareAddress[0])
+	ctx, keeper := testutil.CreateTestKeeperAndContext(t, spareAddress[0])
 	ctx = ctx.WithBlockGasMeter(sdk.NewGasMeter(200000))
 
 	keeper.SetParams(ctx, params)
@@ -650,7 +635,7 @@ func TestContractRewardsWithoutDappInflation(t *testing.T) {
 	// Tracking new block with multiple tx tracking obj
 	keeper.TrackNewBlock(ctx)
 
-	CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
+	testutil.CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
 		{
 			MaxGasAllowed:      10,
 			MaxContractRewards: []sdk.DecCoin{firstTxMaxContractReward[0], firstTxMaxContractReward[1]},
@@ -723,7 +708,7 @@ func TestContractRewardsWithoutGasRebate(t *testing.T) {
 
 	var spareAddress = make([]sdk.AccAddress, 10)
 	for i := 0; i < 10; i++ {
-		spareAddress[i] = GenerateRandomAccAddress()
+		spareAddress[i] = testutil.GenerateRandomAccAddress()
 	}
 
 	type expect struct {
@@ -746,7 +731,7 @@ func TestContractRewardsWithoutGasRebate(t *testing.T) {
 		},
 	}
 
-	ctx, keeper := createTestBaseKeeperAndContext(t, spareAddress[0])
+	ctx, keeper := testutil.CreateTestKeeperAndContext(t, spareAddress[0])
 	ctx = ctx.WithBlockGasMeter(sdk.NewGasMeter(200000))
 
 	keeper.SetParams(ctx, params)
@@ -798,7 +783,7 @@ func TestContractRewardsWithoutGasRebate(t *testing.T) {
 	// Tracking new block with multiple tx tracking obj
 	keeper.TrackNewBlock(ctx)
 
-	CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
+	testutil.CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
 		{
 			MaxGasAllowed:      10,
 			MaxContractRewards: []sdk.DecCoin{firstTxMaxContractReward[0], firstTxMaxContractReward[1]},
@@ -872,7 +857,7 @@ func TestContractRewardWithoutGasRebateAndDappInflation(t *testing.T) {
 
 	var spareAddress = make([]sdk.AccAddress, 10)
 	for i := 0; i < 10; i++ {
-		spareAddress[i] = GenerateRandomAccAddress()
+		spareAddress[i] = testutil.GenerateRandomAccAddress()
 	}
 
 	type expect struct {
@@ -887,7 +872,7 @@ func TestContractRewardWithoutGasRebateAndDappInflation(t *testing.T) {
 		logs:     []*RewardTransferKeeperCallLogs{},
 	}
 
-	ctx, keeper := createTestBaseKeeperAndContext(t, spareAddress[0])
+	ctx, keeper := testutil.CreateTestKeeperAndContext(t, spareAddress[0])
 	ctx = ctx.WithBlockGasMeter(sdk.NewGasMeter(200000))
 
 	keeper.SetParams(ctx, params)
@@ -939,7 +924,7 @@ func TestContractRewardWithoutGasRebateAndDappInflation(t *testing.T) {
 	// Tracking new block with multiple tx tracking obj
 	keeper.TrackNewBlock(ctx)
 
-	CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
+	testutil.CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
 		{
 			MaxGasAllowed:      10,
 			MaxContractRewards: []sdk.DecCoin{firstTxMaxContractReward[0], firstTxMaxContractReward[1]},
@@ -1005,7 +990,7 @@ func TestContractRewardsWithoutGasTracking(t *testing.T) {
 
 	var spareAddress = make([]sdk.AccAddress, 10)
 	for i := 0; i < 10; i++ {
-		spareAddress[i] = GenerateRandomAccAddress()
+		spareAddress[i] = testutil.GenerateRandomAccAddress()
 	}
 
 	type expect struct {
@@ -1020,7 +1005,7 @@ func TestContractRewardsWithoutGasTracking(t *testing.T) {
 		logs:     []*RewardTransferKeeperCallLogs{},
 	}
 
-	ctx, keeper := createTestBaseKeeperAndContext(t, spareAddress[0])
+	ctx, keeper := testutil.CreateTestKeeperAndContext(t, spareAddress[0])
 	ctx = ctx.WithBlockGasMeter(sdk.NewGasMeter(200000))
 
 	keeper.SetParams(ctx, params)
@@ -1072,7 +1057,7 @@ func TestContractRewardsWithoutGasTracking(t *testing.T) {
 	// Tracking new block with multiple tx tracking obj
 	keeper.TrackNewBlock(ctx)
 
-	CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
+	testutil.CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
 		{
 			MaxGasAllowed:      10,
 			MaxContractRewards: []sdk.DecCoin{firstTxMaxContractReward[0], firstTxMaxContractReward[1]},
@@ -1139,7 +1124,7 @@ func TestContractRewardsWithoutGasRebateToUser(t *testing.T) {
 
 	var spareAddress = make([]sdk.AccAddress, 10)
 	for i := 0; i < 10; i++ {
-		spareAddress[i] = GenerateRandomAccAddress()
+		spareAddress[i] = testutil.GenerateRandomAccAddress()
 	}
 
 	type expect struct {
@@ -1164,7 +1149,7 @@ func TestContractRewardsWithoutGasRebateToUser(t *testing.T) {
 		},
 	}
 
-	ctx, keeper := createTestBaseKeeperAndContext(t, spareAddress[0])
+	ctx, keeper := testutil.CreateTestKeeperAndContext(t, spareAddress[0])
 	ctx = ctx.WithBlockGasMeter(sdk.NewGasMeter(200000))
 
 	keeper.SetParams(ctx, params)
@@ -1216,7 +1201,7 @@ func TestContractRewardsWithoutGasRebateToUser(t *testing.T) {
 	// Tracking new block with multiple tx tracking obj
 	keeper.TrackNewBlock(ctx)
 
-	CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
+	testutil.CreateTestBlockEntry(ctx, keeper, gstTypes.BlockGasTracking{TxTrackingInfos: []gstTypes.TransactionTracking{
 		{
 			MaxGasAllowed:      10,
 			MaxContractRewards: []sdk.DecCoin{firstTxMaxContractReward[0], firstTxMaxContractReward[1]},
@@ -1282,100 +1267,4 @@ func TestContractRewardsWithoutGasRebateToUser(t *testing.T) {
 	for i := 0; i < len(expected.rewardsB); i++ {
 		require.Equal(t, expected.rewardsB[i], leftOverEntry.ContractRewards[i])
 	}
-}
-
-// TODO: this is shared test util, that is copied
-// from /keeper/keeper_test, refactor
-func createTestBaseKeeperAndContext(t *testing.T, contractAdmin sdk.AccAddress) (sdk.Context, keeper.Keeper) {
-	encodingConfig := simapp.MakeTestEncodingConfig()
-	appCodec := encodingConfig.Marshaler
-
-	memDB := db.NewMemDB()
-	ms := store.NewCommitMultiStore(memDB)
-
-	mkey := sdk.NewKVStoreKey("test")
-	tkey := sdk.NewTransientStoreKey("transient_test")
-	tstoreKey := sdk.NewTransientStoreKey(gastracker.TStoreKey)
-
-	ms.MountStoreWithDB(mkey, sdk.StoreTypeIAVL, memDB)
-	ms.MountStoreWithDB(tkey, sdk.StoreTypeIAVL, memDB)
-	ms.MountStoreWithDB(storeKey, sdk.StoreTypeIAVL, memDB)
-	ms.MountStoreWithDB(tstoreKey, sdk.StoreTypeTransient, memDB)
-
-	err := ms.LoadLatestVersion()
-	require.NoError(t, err, "Loading latest version should not fail")
-
-	pkeeper := paramskeeper.NewKeeper(appCodec, encodingConfig.Amino, mkey, tkey)
-	subspace := pkeeper.Subspace(gstTypes.ModuleName)
-
-	keeper := keeper.NewGasTrackingKeeper(
-		storeKey,
-		appCodec,
-		subspace,
-		NewTestContractInfoView(contractAdmin.String()),
-		wasmkeeper.NewDefaultWasmGasRegister(),
-		&TestMintParamsKeeper{B: Log},
-	)
-
-	ctx := sdk.NewContext(ms, tmproto.Header{
-		Time: time.Date(2020, time.April, 22, 12, 0, 0, 0, time.UTC),
-	}, false, tmLog.NewTMLogger(os.Stdout))
-
-	params := gstTypes.DefaultParams()
-	subspace.SetParamSet(ctx, &params)
-	return ctx, keeper
-}
-
-func CreateTestKeeperAndContext(t *testing.T, contractAdmin sdk.AccAddress) (sdk.Context, keeper.Keeper) {
-	return createTestBaseKeeperAndContext(t, contractAdmin)
-}
-
-func CreateTestBlockEntry(ctx sdk.Context, k keeper.Keeper, blockTracking gstTypes.BlockGasTracking) {
-	k.TrackNewBlock(ctx)
-	for _, tx := range blockTracking.TxTrackingInfos {
-		k.TrackNewTx(ctx, tx.MaxContractRewards, tx.MaxGasAllowed)
-		for _, op := range tx.ContractTrackingInfos {
-			addr, _ := sdk.AccAddressFromBech32(op.Address)
-			k.TrackContractGasUsage(ctx, addr, wasmTypes.GasConsumptionInfo{
-				VMGas:  op.OriginalVmGas,
-				SDKGas: op.OriginalSdkGas,
-			}, op.Operation)
-		}
-	}
-}
-
-type TestContractInfoView struct {
-	keeper.ContractInfoView
-	adminMap     map[string]string
-	defaultAdmin string
-}
-
-func NewTestContractInfoView(defaultAdmin string) *TestContractInfoView {
-	return &TestContractInfoView{
-		adminMap:     make(map[string]string),
-		defaultAdmin: defaultAdmin,
-	}
-}
-
-func (t *TestContractInfoView) GetContractInfo(_ sdk.Context, contractAddress sdk.AccAddress) *wasmTypes.ContractInfo {
-	if admin, ok := t.adminMap[contractAddress.String()]; ok {
-		return &wasmTypes.ContractInfo{Admin: admin}
-	} else {
-		return &wasmTypes.ContractInfo{Admin: t.defaultAdmin}
-	}
-}
-
-func (t *TestContractInfoView) AddContractToAdminMapping(contractAddress string, admin string) {
-	t.adminMap[contractAddress] = admin
-}
-
-var _ keeper.ContractInfoView = &TestContractInfoView{}
-
-func GenerateRandomAccAddress() sdk.AccAddress {
-	var address sdk.AccAddress = make([]byte, 20)
-	_, err := rand.Read(address)
-	if err != nil {
-		panic(err)
-	}
-	return address
 }

--- a/x/gastracker/testutil/testutil.go
+++ b/x/gastracker/testutil/testutil.go
@@ -1,0 +1,133 @@
+package testutil
+
+import (
+	"crypto/rand"
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	wasmTypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	gstTypes "github.com/archway-network/archway/x/gastracker"
+	"github.com/archway-network/archway/x/gastracker/keeper"
+	"github.com/cosmos/cosmos-sdk/simapp"
+	"github.com/cosmos/cosmos-sdk/store"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	mintTypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
+	"github.com/stretchr/testify/require"
+	tmLog "github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	db "github.com/tendermint/tm-db"
+	"os"
+	"testing"
+	"time"
+)
+
+var storeKey = sdk.NewKVStoreKey(gstTypes.StoreKey)
+
+func createTestBaseKeeperAndContext(t *testing.T, contractAdmin sdk.AccAddress) (sdk.Context, keeper.Keeper) {
+	encodingConfig := simapp.MakeTestEncodingConfig()
+	appCodec := encodingConfig.Marshaler
+
+	memDB := db.NewMemDB()
+	ms := store.NewCommitMultiStore(memDB)
+
+	mkey := sdk.NewKVStoreKey("test")
+	tkey := sdk.NewTransientStoreKey("transient_test")
+	tstoreKey := sdk.NewTransientStoreKey(gstTypes.TStoreKey)
+
+	ms.MountStoreWithDB(mkey, sdk.StoreTypeIAVL, memDB)
+	ms.MountStoreWithDB(tkey, sdk.StoreTypeIAVL, memDB)
+	ms.MountStoreWithDB(storeKey, sdk.StoreTypeIAVL, memDB)
+	ms.MountStoreWithDB(tstoreKey, sdk.StoreTypeTransient, memDB)
+
+	err := ms.LoadLatestVersion()
+	require.NoError(t, err, "Loading latest version should not fail")
+
+	pkeeper := paramskeeper.NewKeeper(appCodec, encodingConfig.Amino, mkey, tkey)
+	subspace := pkeeper.Subspace(gstTypes.ModuleName)
+
+	keeper := keeper.NewGasTrackingKeeper(
+		storeKey,
+		appCodec,
+		subspace,
+		NewTestContractInfoView(contractAdmin.String()),
+		wasmkeeper.NewDefaultWasmGasRegister(),
+		mockMinter{},
+	)
+
+	ctx := sdk.NewContext(ms, tmproto.Header{
+		Height: 10000,
+		Time:   time.Date(2020, time.April, 22, 12, 0, 0, 0, time.UTC),
+	}, false, tmLog.NewTMLogger(os.Stdout))
+
+	params := gstTypes.DefaultParams()
+	subspace.SetParamSet(ctx, &params)
+	return ctx, keeper
+}
+
+func CreateTestKeeperAndContext(t *testing.T, contractAdmin sdk.AccAddress) (sdk.Context, keeper.Keeper) {
+	return createTestBaseKeeperAndContext(t, contractAdmin)
+}
+
+type TestContractInfoView struct {
+	keeper.ContractInfoView
+	adminMap     map[string]string
+	defaultAdmin string
+}
+
+func NewTestContractInfoView(defaultAdmin string) *TestContractInfoView {
+	return &TestContractInfoView{
+		adminMap:     make(map[string]string),
+		defaultAdmin: defaultAdmin,
+	}
+}
+
+func (t *TestContractInfoView) GetContractInfo(_ sdk.Context, contractAddress sdk.AccAddress) *wasmTypes.ContractInfo {
+	if admin, ok := t.adminMap[contractAddress.String()]; ok {
+		return &wasmTypes.ContractInfo{Admin: admin}
+	} else {
+		return &wasmTypes.ContractInfo{Admin: t.defaultAdmin}
+	}
+}
+
+func (t *TestContractInfoView) AddContractToAdminMapping(contractAddress string, admin string) {
+	t.adminMap[contractAddress] = admin
+}
+
+var _ keeper.ContractInfoView = &TestContractInfoView{}
+
+func GenerateRandomAccAddress() sdk.AccAddress {
+	var address sdk.AccAddress = make([]byte, 20)
+	_, err := rand.Read(address)
+	if err != nil {
+		panic(err)
+	}
+	return address
+}
+
+func CreateTestBlockEntry(ctx sdk.Context, k keeper.Keeper, blockTracking gstTypes.BlockGasTracking) {
+	k.TrackNewBlock(ctx)
+	for _, tx := range blockTracking.TxTrackingInfos {
+		k.TrackNewTx(ctx, tx.MaxContractRewards, tx.MaxGasAllowed)
+		for _, op := range tx.ContractTrackingInfos {
+			addr, _ := sdk.AccAddressFromBech32(op.Address)
+			k.TrackContractGasUsage(ctx, addr, wasmTypes.GasConsumptionInfo{
+				VMGas:  op.OriginalVmGas,
+				SDKGas: op.OriginalSdkGas,
+			}, op.Operation)
+		}
+	}
+}
+
+type mockMinter struct{}
+
+func (t mockMinter) GetParams(_ sdk.Context) (params mintTypes.Params) {
+	return mintTypes.Params{
+		MintDenom:     "test",
+		BlocksPerYear: 100,
+	}
+}
+
+func (t mockMinter) GetMinter(_ sdk.Context) (minter mintTypes.Minter) {
+	return mintTypes.Minter{
+		AnnualProvisions: sdk.NewDec(76500),
+	}
+}


### PR DESCRIPTION
Initially TX tracking plus contracts operations were all saved into a single object.
This brings huge performance limitations and issues.

As to add 1 contract operation, you need to unmarshal one single object containing all the txs (and their respective operations) and then append to it, and then marshal it back again.

In blocks with lots of TXs this gets crazy expensive.

So this PR puts every tx tracking information into its own object.

This could be better improved by putting every single operation into its own object and doing all the connections when the block tracking info is fetched. Leaving this for another PR to reduce the scope.

On top of that it also removes copied test utilities.