### PR TITLE
fix: make localnet - override entrypoint in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,9 @@ services:
     image: archwaynetwork/archwayd:latest
     build:
       context: .
-    command: ["sh", "/opt/localnet.sh"]
+    entrypoint:
+      - sh
+      - /opt/localnet.sh
     ports:
       - 9090:9090
       - 26657:26657


### PR DESCRIPTION
Previously running `make localnet` resulted in:

```
❯ docker version
Client:
 Version:           20.10.17

❯ docker-compose version
Docker Compose version 2.6.1

❯ make localnet
docker-compose up
[+] Running 1/1
 ⠿ Container archway-node-1  Recreated                                      0.2s
Attaching to archway-node-1
archway-node-1  | Error: unknown command "sh" for "archwayd"
archway-node-1  |
archway-node-1  | Did you mean this?
archway-node-1  | 	tx
archway-node-1  |
archway-node-1  | Run 'archwayd --help' for usage.
archway-node-1 exited with code 1
```

This PR overrides the archwayd container entrypoint to be the `/opt/localnet.sh` script
