### PR TITLE
fix(version): add the commit info to the current version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 #!/usr/bin/make -f
 
 PACKAGES_SIMTEST=$(shell go list ./... | grep '/simulation')
-# VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
-VERSION := "0.0.5"
+VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
 LEDGER_ENABLED ?= true
 # SDK_PACK := $(shell go list -m github.com/cosmos/cosmos-sdk | sed  's/ /\@/g')


### PR DESCRIPTION
When someone builds from the `main` branch, the version shown in the `archwayd version` command does not give enough information if the binary was created from a tag or a standalone commit. This change in the Makefile fixes this issue.