### PR TITLE
ci: adding changelog check to PRs targeting main

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,0 +1,10 @@
+name: "Ensure changelog updates"
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dangoslen/changelog-enforcer@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,38 @@
-# v0.0.5
+# Changelog
 
-## Breaking Changes
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added 
+
+### Changed 
+
+### Deprecated
+
+### Removed 
+
+### Fixed 
+
+### Security
+
+
+## v0.0.5
+
+### Breaking Changes
 - Update wasmd to 0.25.
 
-## Bug Fixes
+### Fixed
 - Fix logs printing total contract rewards instead of gas rebate reward.
 - Replace info logs for debug logs.
 
-# v0.0.4
-## Breaking Changes
+## v0.0.4
+
+### Breaking Changes
 - Replace wasmd KV store to KV Multistore.
 - Split WasmVM gas & SDK Gas.
 
-# v0.0.3
+## v0.0.3
 - inflation reward calculation now depend upon block gas limit.
 - inflation reward is given even when the gas rebate to the user flag is true.
 - gastracker's begin blocker takes into account gas rebate to user governance switch.


### PR DESCRIPTION
Closes: #240

- Added gh action to ensure CHANGELOG is updated when PR targets to main
- Updating changelog format to [keepachangelog](https://keepachangelog.com/) 