### PR TITLE
fix(x/mint): params.InflationRecipients validates error on multiple recipients with same name

### DIFF
--- a/x/mint/types/params.go
+++ b/x/mint/types/params.go
@@ -169,10 +169,15 @@ func validateInflationRecipients(i interface{}) error {
 		return sdkErrors.Wrap(ErrInvalidInflationRecipient, "inflation recipients not found")
 	}
 	inflationDistribution := sdk.ZeroDec()
+	recipientSeen := map[string]bool{} // to check of same recipient has been configured more than once
 	for _, recipient := range inflationRecipients {
 		if recipient.Recipient == "" {
 			return sdkErrors.Wrap(ErrInvalidInflationRecipient, "inflation recipient module name is empty")
 		}
+		if recipientSeen[recipient.Recipient] {
+			return sdkErrors.Wrap(ErrInvalidInflationRecipient, "inflation recipient module cannot be configured more than once")
+		}
+		recipientSeen[recipient.Recipient] = true
 		inflationDistribution = inflationDistribution.Add(recipient.Ratio)
 	}
 	if !inflationDistribution.Equal(sdk.OneDec()) {

--- a/x/mint/types/params_test.go
+++ b/x/mint/types/params_test.go
@@ -207,6 +207,33 @@ func TestParamsValidate(t *testing.T) {
 			types.ErrInvalidInflationDistribution,
 		},
 		{
+			"invalid inflation recipients: same recipient multiple times",
+			types.Params{
+				MinInflation:     sdk.MustNewDecFromStr("0.2"),
+				MaxInflation:     sdk.MustNewDecFromStr("0.2"),
+				MinBonded:        sdk.MustNewDecFromStr("0.2"),
+				MaxBonded:        sdk.MustNewDecFromStr("0.2"),
+				InflationChange:  sdk.MustNewDecFromStr("0.2"),
+				MaxBlockDuration: time.Hour,
+				InflationRecipients: []*types.InflationRecipient{
+					{
+						Recipient: types.ModuleName,
+						Ratio:     sdk.MustNewDecFromStr("0.1"),
+					},
+					{
+						Recipient: types.ModuleName,
+						Ratio:     sdk.MustNewDecFromStr("0.1"),
+					},
+					{
+						Recipient: authtypes.FeeCollectorName,
+						Ratio:     sdk.MustNewDecFromStr("0.8"),
+					},
+				},
+			},
+			true,
+			types.ErrInvalidInflationRecipient,
+		},
+		{
 			"ok: valid",
 			types.Params{
 				MinInflation:     sdk.MustNewDecFromStr("0.2"),


### PR DESCRIPTION
Previously, `params.Validate()` would pass when there were multiple `params.InflationRecipients` with same name. 
Example: 
```go
[]*types.InflationRecipient {
{Recipient: authtypes.FeeCollectorName, Ratio:  sdk.MustNewDecFromStr("0.4")},
{Recipient: authtypes.FeeCollectorName, Ratio:  sdk.MustNewDecFromStr("0.6")},}
```
this used to be valid before. 

Now it throws `ErrInvalidInflationRecipient` error