### PR TITLE
fix: add safe directory step to the workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,8 +16,9 @@ jobs:
       steps:
         - name: Checkout
           uses: actions/checkout@v3
-          with:
-            set-safe-directory: '/__w/archway/archway'
+        
+        - name: Set safe directory 
+          run: git config --system --add safe.directory '/__w/archway/archway'
 
         - name: Set up Go
           uses: actions/setup-go@v3


### PR DESCRIPTION
This fixes the current issues with the release workflow by adding extra step to the workflow
```
  Error: fatal: detected dubious ownership in repository at '/__w/archway/archway'
```