### PR TITLE
fix(x/rewards): fixed `EstimateTxFees` error when minConsFee and contract flatfee are same denom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
+<!-- 
 ### Added
 
 Contains the new features.
@@ -24,9 +25,17 @@ Contains bug fixes.
 
 ### Improvements
 
-Contains all the PRs that improved the code without changing the behaviours.
+Contains all the PRs that improved the code without changing the behaviours. 
+-->
 
-## [Unreleased]
+## [v0.3.1]
+
+### Fixed
+
+- [#335](https://github.com/archway-network/archway/pull/335) - fixed `EstimateTxFees` erroring when minConsFee and contract premium are same denom
+
+
+## [v0.3.0]
 
 ### Added
 

--- a/x/rewards/keeper/grpc_query.go
+++ b/x/rewards/keeper/grpc_query.go
@@ -105,10 +105,10 @@ func (s *QueryServer) EstimateTxFees(c context.Context, request *types.QueryEsti
 
 	ctx := sdk.UnwrapSDKContext(c)
 
-	fees := []sdk.Coin{}
+	var fees sdk.Coins
 	minConsFee, found := s.keeper.GetMinConsensusFee(ctx)
 	if found {
-		fees = append(fees, sdk.Coin{
+		fees = fees.Add(sdk.Coin{
 			Denom:  minConsFee.Denom,
 			Amount: minConsFee.Amount.MulInt64(int64(request.GasLimit)).RoundInt(),
 		})
@@ -121,13 +121,13 @@ func (s *QueryServer) EstimateTxFees(c context.Context, request *types.QueryEsti
 		}
 		contractFlatFee, found := s.keeper.GetFlatFee(ctx, contractAddr)
 		if found {
-			fees = append(fees, contractFlatFee)
+			fees = fees.Add(contractFlatFee)
 		}
 	}
 
 	return &types.QueryEstimateTxFeesResponse{
 		GasUnitPrice: minConsFee,
-		EstimatedFee: sdk.NewCoins(fees...).Sort(),
+		EstimatedFee: fees.Sort(),
 	}, nil
 }
 


### PR DESCRIPTION
Closes: #334 

* Fixed the sdk.Coins addition such that when both minConsFee and contract flatfee are same denom it doesnt error
* Test case for this issue