### PR TITLE
fix(x/rewards): create block rewards for flat fees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ Contains bug fixes.
 Contains all the PRs that improved the code without changing the behaviours. 
 -->
 
+## [Unreleased]
+
+### Fixed
+
+- [#338](https://github.com/archway-network/archway/pull/338) - fixed issue where contract premium was not completly being sent to the rewards address
+
 ## [v0.3.1]
 
 ### Fixed

--- a/app/ante.go
+++ b/app/ante.go
@@ -76,7 +76,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		// Custom Archway interceptor to track new transactions
 		trackingAnte.NewTxGasTrackingDecorator(options.TrackingKeeper),
 		// Custom Archway fee deduction, which splits fees between x/rewards and x/auth fee collector
-		rewardsAnte.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.RewardsKeeper),
+		rewardsAnte.NewDeductFeeDecorator(options.Codec, options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.RewardsKeeper),
 		// SetPubKeyDecorator must be called before all signature verification decorators
 		ante.NewSetPubKeyDecorator(options.AccountKeeper),
 		ante.NewValidateSigCountDecorator(options.AccountKeeper),

--- a/e2e/rewards_test.go
+++ b/e2e/rewards_test.go
@@ -538,7 +538,7 @@ func (s *E2ETestSuite) TestRewardsFlatFees() {
 
 	// Lets now do the same operations a bunch of times - and by a bunch of times i mean ten times
 	// this should generate quite a few rewards records
-	// each msg execute is in seperate block
+	// each msg execute is in separate block
 	for i := 0; i < 10; i++ {
 		// contract execution to trigger rewards distribution
 		req := voterTypes.MsgExecute{

--- a/e2e/rewards_test.go
+++ b/e2e/rewards_test.go
@@ -458,7 +458,7 @@ func (s *E2ETestSuite) TestTXFailsAfterAnteHandler() {
 
 	chain.NextBlock(1 * time.Second)
 
-	// no rewards because the TX failed.
+	// only rewards record for contract premiums. no rewards record for feerebaes/inflation because because the TX failed.
 	rewards := rewardsKeeper.GetState().RewardsRecord(chain.GetContext()).GetRewardsRecordByRewardsAddress(contractAddr)
 	require.Len(s.T(), rewards, 1)
 	require.Equal(s.T(), flatFees, rewards[0].Rewards[0])

--- a/e2e/rewards_test.go
+++ b/e2e/rewards_test.go
@@ -414,7 +414,7 @@ func (s *E2ETestSuite) TestTXFailsAfterAnteHandler() {
 		RewardsAddress:  contractAddr.String(),
 	})
 
-	err := chain.GetApp().RewardsKeeper.SetFlatFee(chain.GetContext(), senderAcc.Address, rewardsTypes.FlatFee{
+	err := rewardsKeeper.SetFlatFee(chain.GetContext(), senderAcc.Address, rewardsTypes.FlatFee{
 		ContractAddress: contractAddr.String(),
 		FlatFee:         sdk.NewInt64Coin("stake", 1000),
 	})

--- a/e2e/rewards_test.go
+++ b/e2e/rewards_test.go
@@ -460,6 +460,7 @@ func (s *E2ETestSuite) TestTXFailsAfterAnteHandler() {
 
 	// no rewards because the TX failed.
 	rewards := rewardsKeeper.GetState().RewardsRecord(chain.GetContext()).GetRewardsRecordByRewardsAddress(contractAddr)
+	require.Len(s.T(), rewards, 1)
 	require.Equal(s.T(), flatFees, rewards[0].Rewards[0])
 }
 

--- a/x/rewards/ante/ante_utils.go
+++ b/x/rewards/ante/ante_utils.go
@@ -37,6 +37,7 @@ func GetContractFlatFees(ctx sdk.Context, rk RewardsKeeperExpected, codec codec.
 				rk.CreateFlatFeeRewardsRecords(ctx, ca, fee)
 				return sdk.NewCoins(fee), true, nil
 			}
+			return nil, true, nil
 		}
 	case *authz.MsgExec: // if msg is authz msg, unwrap the msg and check if any are wasmTypes.MsgExecuteContract
 		{

--- a/x/rewards/ante/ante_utils.go
+++ b/x/rewards/ante/ante_utils.go
@@ -13,14 +13,19 @@ type RewardsKeeperExpected interface {
 	// Used in MinFeeDecorator
 	GetMinConsensusFee(ctx sdk.Context) (sdk.DecCoin, bool)
 	GetFlatFee(ctx sdk.Context, contractAddr sdk.AccAddress) (sdk.Coin, bool)
-	CreateFlatFeeRewardsRecords(ctx sdk.Context, contractAddress sdk.AccAddress, flatfee sdk.Coin)
+	CreateFlatFeeRewardsRecords(ctx sdk.Context, contractAddress sdk.AccAddress, flatfee sdk.Coins)
 
 	// Used in DeductFeeDecorator
 	TxFeeRebateRatio(ctx sdk.Context) sdk.Dec
 	TrackFeeRebatesRewards(ctx sdk.Context, rewards sdk.Coins)
 }
 
-func GetContractFlatFees(ctx sdk.Context, rk RewardsKeeperExpected, codec codec.BinaryCodec, m sdk.Msg) (fees sdk.Coins, hasWasmMsgs bool, err error) {
+type contractFlatFee struct {
+	ContractAddress sdk.AccAddress
+	FlatFees        sdk.Coins
+}
+
+func GetContractFlatFees(ctx sdk.Context, rk RewardsKeeperExpected, codec codec.BinaryCodec, m sdk.Msg) (contractFlatFees []contractFlatFee, hasWasmMsgs bool, err error) {
 	switch msg := m.(type) {
 	case *wasmTypes.MsgMigrateContract:
 		{
@@ -34,27 +39,26 @@ func GetContractFlatFees(ctx sdk.Context, rk RewardsKeeperExpected, codec codec.
 			}
 			fee, found := rk.GetFlatFee(ctx, ca)
 			if found {
-				rk.CreateFlatFeeRewardsRecords(ctx, ca, fee)
-				return sdk.NewCoins(fee), true, nil
+				contractFlatFees = append(contractFlatFees, contractFlatFee{ContractAddress: ca, FlatFees: sdk.NewCoins(fee)})
+				return contractFlatFees, true, nil
 			}
 			return nil, true, nil
 		}
 	case *authz.MsgExec: // if msg is authz msg, unwrap the msg and check if any are wasmTypes.MsgExecuteContract
 		{
-			var flatfees sdk.Coins
 			for _, v := range msg.Msgs {
 				var wrappedMsg sdk.Msg
 				err := codec.UnpackAny(v, &wrappedMsg)
 				if err != nil {
 					return nil, false, sdkErrors.Wrapf(sdkErrors.ErrUnauthorized, "error decoding authz messages")
 				}
-				fees, hasWasmMsgs, err := GetContractFlatFees(ctx, rk, codec, wrappedMsg)
+				cff, hasWasmMsgs, err := GetContractFlatFees(ctx, rk, codec, wrappedMsg)
 				if err != nil {
 					return nil, hasWasmMsgs, err
 				}
-				flatfees = flatfees.Add(fees...)
+				contractFlatFees = append(contractFlatFees, cff...)
 			}
-			return flatfees, hasWasmMsgs, nil
+			return contractFlatFees, hasWasmMsgs, nil
 		}
 	}
 	return nil, false, nil

--- a/x/rewards/ante/ante_utils.go
+++ b/x/rewards/ante/ante_utils.go
@@ -1,0 +1,60 @@
+package ante
+
+import (
+	wasmTypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkErrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+)
+
+// RewardsKeeperExpected defines the expected interface for the x/rewards keeper.
+type RewardsKeeperExpected interface {
+	// Used in MinFeeDecorator
+	GetMinConsensusFee(ctx sdk.Context) (sdk.DecCoin, bool)
+	GetFlatFee(ctx sdk.Context, contractAddr sdk.AccAddress) (sdk.Coin, bool)
+	CreateFlatFeeRewardsRecords(ctx sdk.Context, contractAddress sdk.AccAddress, flatfee sdk.Coin)
+
+	// Used in DeductFeeDecorator
+	TxFeeRebateRatio(ctx sdk.Context) sdk.Dec
+	TrackFeeRebatesRewards(ctx sdk.Context, rewards sdk.Coins)
+}
+
+func GetContractFlatFees(ctx sdk.Context, rk RewardsKeeperExpected, codec codec.BinaryCodec, m sdk.Msg) (fees sdk.Coins, hasWasmMsgs bool, err error) {
+	switch msg := m.(type) {
+	case *wasmTypes.MsgMigrateContract:
+		{
+			return nil, true, nil
+		}
+	case *wasmTypes.MsgExecuteContract: // if msg is contract execute, fetch flatfee for msg.Contract address
+		{
+			ca, err := sdk.AccAddressFromBech32(msg.Contract)
+			if err != nil {
+				return nil, true, err
+			}
+			fee, found := rk.GetFlatFee(ctx, ca)
+			if found {
+				rk.CreateFlatFeeRewardsRecords(ctx, ca, fee)
+				return sdk.NewCoins(fee), true, nil
+			}
+		}
+	case *authz.MsgExec: // if msg is authz msg, unwrap the msg and check if any are wasmTypes.MsgExecuteContract
+		{
+			var flatfees sdk.Coins
+			for _, v := range msg.Msgs {
+				var wrappedMsg sdk.Msg
+				err := codec.UnpackAny(v, &wrappedMsg)
+				if err != nil {
+					return nil, false, sdkErrors.Wrapf(sdkErrors.ErrUnauthorized, "error decoding authz messages")
+				}
+				fees, hasWasmMsgs, err := GetContractFlatFees(ctx, rk, codec, wrappedMsg)
+				if err != nil {
+					return nil, hasWasmMsgs, err
+				}
+				flatfees = flatfees.Add(fees...)
+			}
+			return flatfees, hasWasmMsgs, nil
+		}
+	}
+	return nil, false, nil
+}

--- a/x/rewards/ante/fee_deduction.go
+++ b/x/rewards/ante/fee_deduction.go
@@ -102,14 +102,14 @@ func (dfd DeductFeeDecorator) deductFees(ctx sdk.Context, tx sdk.Tx, acc authTyp
 	// Check if transaction has wasmd operations
 	hasWasmMsgs := false
 	for _, m := range tx.GetMsgs() {
-		flatFees, hwm, err := GetContractFlatFees(ctx, dfd.rewardsKeeper, dfd.codec, m)
+		fees, hwm, err := GetContractFlatFees(ctx, dfd.rewardsKeeper, dfd.codec, m)
 		if err != nil {
 			return err
 		}
 		if !hasWasmMsgs {
 			hasWasmMsgs = hwm //set hasWasmMsgs as true if its false. if its true, do nothing
 		}
-		flatFees = flatFees.Add(flatFees...)
+		flatFees = flatFees.Add(fees...)
 	}
 
 	// Send everything to the fee collector account if rewards are disabled or transaction is not wasm related

--- a/x/rewards/ante/fee_deduction_test.go
+++ b/x/rewards/ante/fee_deduction_test.go
@@ -30,7 +30,9 @@ func TestRewardsFeeDeductionAnteHandler(t *testing.T) {
 		rewardsBalanceDiffExpected      string // expected x/rewards module balance diff [sdk.Coins]
 	}
 
-	mockWasmExecuteMsg := &wasmdTypes.MsgExecuteContract{}
+	mockWasmExecuteMsg := &wasmdTypes.MsgExecuteContract{
+		Contract: e2eTesting.GenContractAddresses(1)[0].String(),
+	}
 
 	newStakeCoin := func(amt uint64) sdk.Coin {
 		return sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewIntFromUint64(amt))

--- a/x/rewards/ante/fee_deduction_test.go
+++ b/x/rewards/ante/fee_deduction_test.go
@@ -132,7 +132,7 @@ func TestRewardsFeeDeductionAnteHandler(t *testing.T) {
 			)
 
 			// Call the deduction Ante handler manually
-			anteHandler := ante.NewDeductFeeDecorator(chain.GetApp().AccountKeeper, chain.GetApp().BankKeeper, chain.GetApp().FeeGrantKeeper, chain.GetApp().RewardsKeeper)
+			anteHandler := ante.NewDeductFeeDecorator(chain.GetAppCodec(), chain.GetApp().AccountKeeper, chain.GetApp().BankKeeper, chain.GetApp().FeeGrantKeeper, chain.GetApp().RewardsKeeper)
 			_, err = anteHandler.AnteHandle(ctx, tx, false, testutils.NoopAnteHandler)
 			if tc.errExpected {
 				require.Error(t, err)

--- a/x/rewards/ante/min_cons_fee.go
+++ b/x/rewards/ante/min_cons_fee.go
@@ -14,6 +14,7 @@ import (
 type RewardsFeeReaderExpected interface {
 	GetMinConsensusFee(ctx sdk.Context) (sdk.DecCoin, bool)
 	GetFlatFee(ctx sdk.Context, contractAddr sdk.AccAddress) (sdk.Coin, bool)
+	CreateFlatFeeRewardsRecords(ctx sdk.Context, contractAddress sdk.AccAddress, flatfee sdk.Coin)
 }
 
 // MinFeeDecorator rejects transaction if its fees are less than minimum fees defined by the x/rewards module.
@@ -87,6 +88,7 @@ func (mfd MinFeeDecorator) getContractFlatFees(ctx sdk.Context, m sdk.Msg) (sdk.
 			}
 			fee, found := mfd.rewardsKeeper.GetFlatFee(ctx, ca)
 			if found {
+				mfd.rewardsKeeper.CreateFlatFeeRewardsRecords(ctx, ca, fee)
 				return sdk.NewCoins(fee), nil
 			}
 		}

--- a/x/rewards/ante/min_cons_fee.go
+++ b/x/rewards/ante/min_cons_fee.go
@@ -55,11 +55,14 @@ func (mfd MinFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool,
 
 	// Get flatfees for any contracts being called in the tx.msgs
 	for _, m := range tx.GetMsgs() {
-		flatFees, _, err := GetContractFlatFees(ctx, mfd.rewardsKeeper, mfd.codec, m)
+		contractFlatFees, _, err := GetContractFlatFees(ctx, mfd.rewardsKeeper, mfd.codec, m)
 		if err != nil {
 			return ctx, err
 		}
-		expectedFees = expectedFees.Add(flatFees...)
+		for _, cff := range contractFlatFees {
+			mfd.rewardsKeeper.CreateFlatFeeRewardsRecords(ctx, cff.ContractAddress, cff.FlatFees)
+			expectedFees = expectedFees.Add(cff.FlatFees...)
+		}
 	}
 
 	txFees := feeTx.GetFee()

--- a/x/rewards/ante/min_cons_fee.go
+++ b/x/rewards/ante/min_cons_fee.go
@@ -4,7 +4,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkErrors "github.com/cosmos/cosmos-sdk/types/errors"
-	bankTypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 	"github.com/archway-network/archway/pkg"
 )
@@ -16,7 +15,6 @@ import (
 type MinFeeDecorator struct {
 	codec         codec.BinaryCodec
 	rewardsKeeper RewardsKeeperExpected
-	bankKeeper    bankTypes.BankKeeper
 }
 
 // NewMinFeeDecorator returns a new MinFeeDecorator instance.

--- a/x/rewards/ante/min_cons_fee.go
+++ b/x/rewards/ante/min_cons_fee.go
@@ -1,21 +1,13 @@
 package ante
 
 import (
-	wasmTypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkErrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/cosmos/cosmos-sdk/x/authz"
+	bankTypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 	"github.com/archway-network/archway/pkg"
 )
-
-// RewardsFeeReaderExpected defines the expected interface for the x/rewards keeper.
-type RewardsFeeReaderExpected interface {
-	GetMinConsensusFee(ctx sdk.Context) (sdk.DecCoin, bool)
-	GetFlatFee(ctx sdk.Context, contractAddr sdk.AccAddress) (sdk.Coin, bool)
-	CreateFlatFeeRewardsRecords(ctx sdk.Context, contractAddress sdk.AccAddress, flatfee sdk.Coin)
-}
 
 // MinFeeDecorator rejects transaction if its fees are less than minimum fees defined by the x/rewards module.
 // Estimation is done using the minimum consensus fee value which is the minimum gas unit price.
@@ -23,11 +15,12 @@ type RewardsFeeReaderExpected interface {
 // CONTRACT: Tx must implement FeeTx interface to use MinFeeDecorator.
 type MinFeeDecorator struct {
 	codec         codec.BinaryCodec
-	rewardsKeeper RewardsFeeReaderExpected
+	rewardsKeeper RewardsKeeperExpected
+	bankKeeper    bankTypes.BankKeeper
 }
 
 // NewMinFeeDecorator returns a new MinFeeDecorator instance.
-func NewMinFeeDecorator(codec codec.BinaryCodec, rk RewardsFeeReaderExpected) MinFeeDecorator {
+func NewMinFeeDecorator(codec codec.BinaryCodec, rk RewardsKeeperExpected) MinFeeDecorator {
 	return MinFeeDecorator{
 		codec:         codec,
 		rewardsKeeper: rk,
@@ -64,7 +57,7 @@ func (mfd MinFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool,
 
 	// Get flatfees for any contracts being called in the tx.msgs
 	for _, m := range tx.GetMsgs() {
-		flatFees, err := mfd.getContractFlatFees(ctx, m)
+		flatFees, _, err := GetContractFlatFees(ctx, mfd.rewardsKeeper, mfd.codec, m)
 		if err != nil {
 			return ctx, err
 		}
@@ -76,39 +69,4 @@ func (mfd MinFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool,
 		return next(ctx, tx, simulate)
 	}
 	return ctx, sdkErrors.Wrapf(sdkErrors.ErrInsufficientFee, "tx fee %s is less than min fee: %s", txFees, expectedFees.String())
-}
-
-func (mfd MinFeeDecorator) getContractFlatFees(ctx sdk.Context, m sdk.Msg) (sdk.Coins, error) {
-	switch msg := m.(type) {
-	case *wasmTypes.MsgExecuteContract: // if msg is contract execute, fetch flatfee for msg.Contract address
-		{
-			ca, err := sdk.AccAddressFromBech32(msg.Contract)
-			if err != nil {
-				return nil, err
-			}
-			fee, found := mfd.rewardsKeeper.GetFlatFee(ctx, ca)
-			if found {
-				mfd.rewardsKeeper.CreateFlatFeeRewardsRecords(ctx, ca, fee)
-				return sdk.NewCoins(fee), nil
-			}
-		}
-	case *authz.MsgExec: // if msg is authz msg, unwrap the msg and check if any are wasmTypes.MsgExecuteContract
-		{
-			var flatfees sdk.Coins
-			for _, v := range msg.Msgs {
-				var wrappedMsg sdk.Msg
-				err := mfd.codec.UnpackAny(v, &wrappedMsg)
-				if err != nil {
-					return nil, sdkErrors.Wrapf(sdkErrors.ErrUnauthorized, "error decoding authz messages")
-				}
-				fees, err := mfd.getContractFlatFees(ctx, wrappedMsg)
-				if err != nil {
-					return nil, err
-				}
-				flatfees = flatfees.Add(fees...)
-			}
-			return flatfees, nil
-		}
-	}
-	return nil, nil
 }

--- a/x/rewards/ante/min_cons_fee_test.go
+++ b/x/rewards/ante/min_cons_fee_test.go
@@ -117,6 +117,7 @@ func TestRewardsContractFlatFeeAnteHandler(t *testing.T) {
 	contractViewer.AddContractAdmin(contractFlatFeeDiffDenomSet.String(), contractAdminAcc.Address.String())
 	var metaCurrentDiff rewardsTypes.ContractMetadata
 	metaCurrentDiff.ContractAddress = contractFlatFeeDiffDenomSet.String()
+	metaCurrentDiff.RewardsAddress = contractAdminAcc.Address.String()
 	metaCurrentDiff.OwnerAddress = contractAdminAcc.Address.String()
 	err = chain.GetApp().RewardsKeeper.SetContractMetadata(ctx, contractAdminAcc.Address, contractFlatFeeDiffDenomSet, metaCurrentDiff)
 	require.NoError(t, err)
@@ -132,6 +133,7 @@ func TestRewardsContractFlatFeeAnteHandler(t *testing.T) {
 	contractViewer.AddContractAdmin(contractFlatFeeSameDenomSet.String(), contractAdminAcc.Address.String())
 	var metaCurrentSame rewardsTypes.ContractMetadata
 	metaCurrentSame.ContractAddress = contractFlatFeeSameDenomSet.String()
+	metaCurrentSame.RewardsAddress = contractAdminAcc.Address.String()
 	metaCurrentSame.OwnerAddress = contractAdminAcc.Address.String()
 	err = chain.GetApp().RewardsKeeper.SetContractMetadata(ctx, contractAdminAcc.Address, contractFlatFeeSameDenomSet, metaCurrentSame)
 	require.NoError(t, err)

--- a/x/rewards/keeper/distribution.go
+++ b/x/rewards/keeper/distribution.go
@@ -37,23 +37,9 @@ type (
 func (k Keeper) AllocateBlockRewards(ctx sdk.Context, height int64) {
 	blockDistrState := k.estimateBlockGasUsage(ctx, height)
 	blockDistrState = k.estimateBlockRewards(ctx, blockDistrState)
-	k.createFlatFeeRewards(ctx, height)
 	k.createRewardsRecords(ctx, blockDistrState)
 	k.cleanupRewardsPool(ctx, blockDistrState)
 	k.cleanupTracking(ctx, height)
-}
-
-func (k Keeper) createFlatFeeRewards(ctx sdk.Context, height int64) {
-	blockGasTrackingInfo := k.trackingKeeper.GetBlockTrackingInfo(ctx, height)
-	for _, txs := range blockGasTrackingInfo.GetTxs() {
-		for _, contractOp := range txs.GetContractOperations() {
-			contractAddr := sdk.MustAccAddressFromBech32(contractOp.ContractAddress)
-			fee, found := k.GetFlatFee(ctx, contractAddr)
-			if found {
-				k.CreateFlatFeeRewardsRecords(ctx, contractAddr, fee)
-			}
-		}
-	}
 }
 
 // estimateBlockGasUsage creates a new distribution state for the given block height.

--- a/x/rewards/keeper/flat_fee.go
+++ b/x/rewards/keeper/flat_fee.go
@@ -41,3 +41,13 @@ func (k Keeper) GetFlatFee(ctx sdk.Context, contractAddr sdk.AccAddress) (sdk.Co
 
 	return fee, true
 }
+
+func (k Keeper) CreateFlatFeeRewardsRecords(ctx sdk.Context, contractAddress sdk.AccAddress, flatfee sdk.Coin) {
+	rewardsRecordState := k.state.RewardsRecord(ctx)
+	calculationHeight, calculationTime := ctx.BlockHeight(), ctx.BlockTime()
+
+	metadata := k.GetContractMetadata(ctx, contractAddress)
+	rewardsAddr := sdk.MustAccAddressFromBech32(metadata.RewardsAddress)
+
+	rewardsRecordState.CreateRewardsRecord(rewardsAddr, sdk.NewCoins(flatfee), calculationHeight, calculationTime)
+}

--- a/x/rewards/keeper/flat_fee.go
+++ b/x/rewards/keeper/flat_fee.go
@@ -42,6 +42,7 @@ func (k Keeper) GetFlatFee(ctx sdk.Context, contractAddr sdk.AccAddress) (sdk.Co
 	return fee, true
 }
 
+// CreateFlatFeeRewardsRecords creates a rewards record for the flatfees of the given contract
 func (k Keeper) CreateFlatFeeRewardsRecords(ctx sdk.Context, contractAddress sdk.AccAddress, flatfees sdk.Coins) {
 	rewardsRecordState := k.state.RewardsRecord(ctx)
 	calculationHeight, calculationTime := ctx.BlockHeight(), ctx.BlockTime()

--- a/x/rewards/keeper/flat_fee.go
+++ b/x/rewards/keeper/flat_fee.go
@@ -42,12 +42,12 @@ func (k Keeper) GetFlatFee(ctx sdk.Context, contractAddr sdk.AccAddress) (sdk.Co
 	return fee, true
 }
 
-func (k Keeper) CreateFlatFeeRewardsRecords(ctx sdk.Context, contractAddress sdk.AccAddress, flatfee sdk.Coin) {
+func (k Keeper) CreateFlatFeeRewardsRecords(ctx sdk.Context, contractAddress sdk.AccAddress, flatfees sdk.Coins) {
 	rewardsRecordState := k.state.RewardsRecord(ctx)
 	calculationHeight, calculationTime := ctx.BlockHeight(), ctx.BlockTime()
 
 	metadata := k.GetContractMetadata(ctx, contractAddress)
 	rewardsAddr := sdk.MustAccAddressFromBech32(metadata.RewardsAddress)
 
-	rewardsRecordState.CreateRewardsRecord(rewardsAddr, sdk.NewCoins(flatfee), calculationHeight, calculationTime)
+	rewardsRecordState.CreateRewardsRecord(rewardsAddr, flatfees, calculationHeight, calculationTime)
 }


### PR DESCRIPTION
Ref: https://github.com/archway-network/archway/issues/336

* Modified MinFeeDecorator such that when a contract is found with flatfees configured, the relevant rewards records are created
* Modified DeductFeeDecorator such that when a contract is found with flatfees configured, the relevant amount is sent from the sender's acc to the rewards collector account
* Some refactor of x/rewards antehandlers in general with moving common stuff to ante_utils
* Added TestRewardsFlatFees to e2e rewards_tests which checks that post a successful tx completion, the relevant records for contract premium are created. 
