### PR TITLE
fix: arm64 builds working with goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,8 +16,8 @@ jobs:
       steps:
         - name: Checkout
           uses: actions/checkout@v3
-        
-        - name: Set safe directory 
+
+        - name: Set safe directory
           run: git config --system --add safe.directory '/__w/archway/archway'
 
         - name: Set up Go
@@ -25,7 +25,6 @@ jobs:
           with:
             go-version-file: go.mod
 
-        # Add QEMU to support multi arch build in the future
         - name: Set up QEMU
           uses: docker/setup-qemu-action@v2
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,19 +1,43 @@
 before:
   hooks:
-    - wget https://github.com/CosmWasm/wasmvm/releases/download/v1.1.1/libwasmvm_muslc.x86_64.a -O /lib/libwasmvm_muslc.a
-    - apt install musl-dev
 builds:
   - id: linux-amd64
     main: ./cmd/archwayd
     binary: archwayd
+    hooks:
+      pre:
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/v1.1.1/libwasmvm_muslc.x86_64.a -O /lib/libwasmvm_muslc.a
+        - apt install musl-dev
     goos:
       - linux
     goarch:
       - amd64
-      - arm64
     env:
       - CGO_ENABLED=1
       - CC=x86_64-linux-gnu-gcc
+    flags:
+      - -mod=readonly
+    ldflags:
+      - -s -w -X main.commit={{.Commit}} -X main.date={{ .CommitDate }} -X github.com/cosmos/cosmos-sdk/version.Name=archway -X github.com/cosmos/cosmos-sdk/version.AppName=archway -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }} -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
+      - -linkmode=external
+      - -extldflags '-Wl,-z,muldefs -static -lm'
+    tags:
+      - netgo
+      - muslc
+  - id: linux-arm64
+    main: ./cmd/archwayd
+    binary: archwayd
+    hooks:
+      pre:
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/v1.1.1/libwasmvm_muslc.aarch64.a -O /usr/local/lib/libwasmvm_muslc.a
+        - apt install musl-dev
+    goos:
+      - linux
+    goarch:
+      - arm64
+    env:
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
     flags:
       - -mod=readonly
     ldflags:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,13 +1,12 @@
 before:
   hooks:
+    - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.LIBWASM_VERSION }}/libwasmvm_muslc.x86_64.a -O /lib/libwasmvm_muslc.a
+    - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.LIBWASM_VERSION }}/libwasmvm_muslc.aarch64.a -O /usr/local/lib/libwasmvm_muslc.a
+    - apt install musl-dev=1.2.2-1
 builds:
   - id: linux-amd64
     main: ./cmd/archwayd
     binary: archwayd
-    hooks:
-      pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/v1.1.1/libwasmvm_muslc.x86_64.a -O /lib/libwasmvm_muslc.a
-        - apt install musl-dev=1.2.2-1
     goos:
       - linux
     goarch:
@@ -27,10 +26,6 @@ builds:
   - id: linux-arm64
     main: ./cmd/archwayd
     binary: archwayd
-    hooks:
-      pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/v1.1.1/libwasmvm_muslc.aarch64.a -O /usr/local/lib/libwasmvm_muslc.a
-        - apt install musl-dev=1.2.2-1
     goos:
       - linux
     goarch:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
     env:
       - CGO_ENABLED=1
       - CC=x86_64-linux-gnu-gcc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,7 @@ builds:
     hooks:
       pre:
         - wget https://github.com/CosmWasm/wasmvm/releases/download/v1.1.1/libwasmvm_muslc.x86_64.a -O /lib/libwasmvm_muslc.a
-        - apt install musl-dev
+        - apt install musl-dev=1.2.2-1
     goos:
       - linux
     goarch:
@@ -30,7 +30,7 @@ builds:
     hooks:
       pre:
         - wget https://github.com/CosmWasm/wasmvm/releases/download/v1.1.1/libwasmvm_muslc.aarch64.a -O /usr/local/lib/libwasmvm_muslc.a
-        - apt install musl-dev
+        - apt install musl-dev=1.2.2-1
     goos:
       - linux
     goarch:

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ DOCKER_BUF := $(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace $(
 HTTPS_GIT := https://github.com/archway-network/archway.git
 CURRENT_DIR := $(shell pwd)
 
+# library versions
+LIBWASM_VERSION = $(shell go list -m -f '{{ .Version }}' github.com/CosmWasm/wasmvm)
+
 export GO111MODULE = on
 
 # process build tags
@@ -202,7 +205,7 @@ localnet:
 	docker-compose up
 
 release:
-	docker run --rm -v "$(CURDIR)":/code -w /code goreleaser/goreleaser-cross:v1.19.5 --skip-publish --rm-dist
+	docker run --rm -v "$(CURDIR)":/code -w /code -e LIBWASM_VERSION=$(LIBWASM_VERSION) goreleaser/goreleaser-cross:v1.19.5 --skip-publish --clean
 
 check-vuln-deps:
 	go list -json -deps ./... | docker run --rm -i sonatypecommunity/nancy:latest sleuth

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ localnet:
 	docker-compose up
 
 release:
-	docker run --rm -v "$(CURDIR)":/code -w /code -e LIBWASM_VERSION=$(LIBWASM_VERSION) goreleaser/goreleaser-cross:v1.19.5 --skip-publish --clean
+	docker run --rm -v "$(CURDIR)":/code -w /code -e LIBWASM_VERSION=$(LIBWASM_VERSION) goreleaser/goreleaser-cross:v1.19.5 --skip-publish --rm-dist
 
 check-vuln-deps:
 	go list -json -deps ./... | docker run --rm -i sonatypecommunity/nancy:latest sleuth


### PR DESCRIPTION
Previous solution on building the arm64 binaries failed due to CGO limitations.
This PR now fixes those issues.

Tested with:
```
make release
```