### PR TITLE
docs: bringing changelog upto date with the releases 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,13 @@ Contains bug fixes.
 
 Contains all the PRs that improved the code without changing the behaviours. 
 -->
-## [Unreleased]
+## [v0.5.2]
+
+### Fixed
+
+- [#382](https://github.com/archway-network/archway/pull/382) - adjust default power reduction
+
+## [v0.5.0]
 
 ### Breaking Changes 
 
@@ -66,7 +72,6 @@ Contains all the PRs that improved the code without changing the behaviours.
 - [#368](https://github.com/archway-network/archway/pull/368) - github actions should fetch tags as well for deploy workflow
 - [#369](https://github.com/archway-network/archway/pull/369) - CODEOWNERS: small set to expand, not large set that filters
 - [#370](https://github.com/archway-network/archway/pull/370) - login to ghcr
-- [#382](https://github.com/archway-network/archway/pull/382) - adjust default power reduction
 
 ### Changed
 
@@ -76,8 +81,6 @@ Contains all the PRs that improved the code without changing the behaviours.
     - docs/README.md
 - [#365](https://github.com/archway-network/archway/pull/356) - Disallow setting module accounts as reward address
 - [#355](https://github.com/archway-network/archway/pull/355) - chore: Update titus genesis defaults
-
-### Deprecated
 
 ### Removed
 


### PR DESCRIPTION
The changelog was inaccurate with the releases and tags. This updates the changes 