### PR TITLE
fix: Add upgrade handler for 0.6 back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Contains all the PRs that improved the code without changing the behaviours.
 - [#401](https://github.com/archway-network/archway/pull/401) - Update libwasmvm version to correct one in Dockerfile.deprecated
 - [#402](https://github.com/archway-network/archway/pull/402) - Bump wasmvm version to 1.2.4
 - [#403](https://github.com/archway-network/archway/pull/403) - Update libwasmvm version to correct one for wasmvm 1.2.4
+- [#406](https://github.com/archway-network/archway/pull/406) - Add upgrade hanlder for v0.6.0 back to prevent downgrade check from panic / consensus failure;
 
 ## [v1.0.0-rc.1]
 

--- a/app/app_upgrades.go
+++ b/app/app_upgrades.go
@@ -6,11 +6,14 @@ import (
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	"github.com/archway-network/archway/app/upgrades"
+	upgrade_0_6 "github.com/archway-network/archway/app/upgrades/06"
 )
 
 // UPGRADES
 
-var Upgrades = []upgrades.Upgrade{}
+var Upgrades = []upgrades.Upgrade{
+	upgrade_0_6.Upgrade, // v0.6.0
+}
 
 func (app *ArchwayApp) setupUpgrades() {
 	app.setUpgradeHandlers()

--- a/app/upgrades/06/upgrades.go
+++ b/app/upgrades/06/upgrades.go
@@ -1,0 +1,25 @@
+package upgrade06
+
+import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	ibcfeetypes "github.com/cosmos/ibc-go/v4/modules/apps/29-fee/types"
+
+	"github.com/archway-network/archway/app/upgrades"
+)
+
+const Name = "v0.6.0"
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName: Name,
+	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator) upgradetypes.UpgradeHandler {
+		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			return mm.RunMigrations(ctx, cfg, fromVM)
+		}
+	},
+	StoreUpgrades: storetypes.StoreUpgrades{
+		Added: []string{ibcfeetypes.ModuleName},
+	},
+}


### PR DESCRIPTION
This should address the issue where --skip-upgrade-handler still results in a panic, as CosmosSDK is checking for a downgraded binary... thus the last applied upgrade will always be needed even when using --skip-upgrade-handler;