### PR TITLE
fix: Remove genesis module msg logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ Contains bug fixes.
 
 Contains all the PRs that improved the code without changing the behaviours. 
 -->
+## [v1.0.0-rc.3]
+
+### Removed
+
+- [#408](https://github.com/archway-network/archway/pull/408) - Remove genesis msg logging as it impacts network start up performance.
+
 ## [v1.0.0-rc.2]
 
 ### Fixes

--- a/x/genmsg/genesis.go
+++ b/x/genmsg/genesis.go
@@ -2,7 +2,6 @@ package genmsg
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
@@ -59,11 +58,12 @@ func initGenesis(context sdk.Context, cdc codec.JSONCodec, router MessageRouter,
 		if handler == nil {
 			return fmt.Errorf("at index %d: no handler for message %T %s", i, msg, msg)
 		}
-		resp, err := handler(context, msg)
+		// resp, err := handler(context, msg)
+		_, err = handler(context, msg)
 		if err != nil {
 			return fmt.Errorf("at index %d: message processing: %w", i, err)
 		}
-		log.Printf("message %d processed %s: %s", i, msg, resp.String())
+		// log.Printf("message %d processed %s: %s", i, msg, resp.String())
 	}
 	return nil
 }


### PR DESCRIPTION
Message logging may significantly impact network start up performance due to excessive terminal output;