### PR TITLE
ci: using actions/setup-go v4 which internally handles caching

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v4
         with:
           PATTERNS: |
@@ -17,18 +17,9 @@ jobs:
             go.mod
             go.sum
       - name: Set up Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: ~1.19
-      - name: Setup Golang caches
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-golang-
+          go-version-file: 'go.mod'
       - name: Build
         run: go build -v ./...
       - name: Test


### PR DESCRIPTION
- Upgrade actions/setup-g from v3 to v4 as v4 handles the caching and we need not explicitly set it up. [src](https://github.com/actions/setup-go)