### PR TITLE
fix: fixing incorrect gas estimation when running with `--dry-run` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Contains bug fixes.
 Contains all the PRs that improved the code without changing the behaviours. 
 -->
 
-## [unreleased]
+## [v1.0.1]
 
 - [#411](https://github.com/archway-network/archway/pull/411) - Update repository readme with correct docker containers.
 - [#413](https://github.com/archway-network/archway/pull/413) - Fixing incorrect gas estimation when running with `--dry-run` flag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Contains all the PRs that improved the code without changing the behaviours.
 ## [unreleased]
 
 - [#411](https://github.com/archway-network/archway/pull/411) - Update repository readme with correct docker containers.
+- [#413](https://github.com/archway-network/archway/pull/413) - Fixing incorrect gas estimation when running with `--dry-run` flag
 
 ## [v1.0.0]
 

--- a/x/rewards/ante/min_cons_fee.go
+++ b/x/rewards/ante/min_cons_fee.go
@@ -25,11 +25,6 @@ func NewMinFeeDecorator(codec codec.BinaryCodec, rk RewardsKeeperExpected) MinFe
 
 // AnteHandle implements the ante.AnteDecorator interface.
 func (mfd MinFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
-	// Skip fee verification for simulation (--dry-run)
-	if simulate {
-		return next(ctx, tx, simulate)
-	}
-
 	feeTx, ok := tx.(sdk.FeeTx)
 	if !ok {
 		return ctx, sdkErrors.Wrap(sdkErrors.ErrTxDecode, "Tx must be a FeeTx")
@@ -57,7 +52,7 @@ func (mfd MinFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool,
 	}
 
 	txFees := feeTx.GetFee()
-	if expectedFees.IsZero() || txFees.IsAllGTE(expectedFees) {
+	if simulate || expectedFees.IsZero() || txFees.IsAllGTE(expectedFees) {
 		return next(ctx, tx, simulate)
 	}
 	return ctx, sdkErrors.Wrapf(sdkErrors.ErrInsufficientFee, "tx fee %s is less than min fee: %s", txFees, expectedFees.String())


### PR DESCRIPTION
* Changes to not skip the Minimum Consensus Fee ante handler when simulating the transaction. Would result in incorrect gas estimates, especially when contract premiums were setup.  