### PR TITLE
fix: preventing user from setting contract flat fee if rewards address is not set 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ Contains bug fixes.
 Contains all the PRs that improved the code without changing the behaviours. 
 -->
 
+## [Unreleased]
+
+### Fixed
+
+- [#414](https://github.com/archway-network/archway/pull/414) - Preventing user from setting contract flat fee if rewards address is not set 
+
 ## [v1.0.1]
 
 - [#411](https://github.com/archway-network/archway/pull/411) - Update repository readme with correct docker containers.

--- a/x/rewards/keeper/flat_fee.go
+++ b/x/rewards/keeper/flat_fee.go
@@ -21,6 +21,9 @@ func (k Keeper) SetFlatFee(ctx sdk.Context, senderAddr sdk.AccAddress, feeUpdate
 	if feeUpdate.FlatFee.Amount.IsZero() {
 		k.state.FlatFee(ctx).RemoveFee(feeUpdate.MustGetContractAddress())
 	} else {
+		if contractInfo.RewardsAddress == "" {
+			return sdkErrors.Wrap(types.ErrMetadataNotFound, "flat_fee can only be when rewards address has been configured")
+		}
 		k.state.FlatFee(ctx).SetFee(feeUpdate.MustGetContractAddress(), feeUpdate.FlatFee)
 	}
 

--- a/x/rewards/keeper/flat_fee_test.go
+++ b/x/rewards/keeper/flat_fee_test.go
@@ -31,6 +31,17 @@ func (s *KeeperTestSuite) TestSetFlatFee() {
 	metaCurrent.OwnerAddress = contractAdminAcc.Address.String()
 	_ = keeper.SetContractMetadata(ctx, contractAdminAcc.Address, contractAddr, metaCurrent)
 
+	s.Run("Fail: rewards address not set", func() {
+		err := keeper.SetFlatFee(ctx, contractAdminAcc.Address, rewardsTypes.FlatFee{
+			ContractAddress: contractAddr.String(),
+			FlatFee:         fee,
+		})
+		s.Assert().ErrorIs(err, rewardsTypes.ErrMetadataNotFound)
+	})
+
+	metaCurrent.RewardsAddress = contractAdminAcc.Address.String()
+	_ = keeper.SetContractMetadata(ctx, contractAdminAcc.Address, contractAddr, metaCurrent)
+
 	s.Run("OK: set flat fee", func() {
 		err := keeper.SetFlatFee(ctx, contractAdminAcc.Address, rewardsTypes.FlatFee{
 			ContractAddress: contractAddr.String(),

--- a/x/rewards/keeper/grpc_query_test.go
+++ b/x/rewards/keeper/grpc_query_test.go
@@ -154,6 +154,7 @@ func (s *KeeperTestSuite) TestGRPC_EstimateTxFees() {
 		err := k.SetContractMetadata(ctx, contractAdminAcc.Address, contractAddr, rewardsTypes.ContractMetadata{
 			ContractAddress: contractAddr.String(),
 			OwnerAddress:    contractAdminAcc.Address.String(),
+			RewardsAddress:  contractAdminAcc.Address.String(),
 		})
 		s.Require().NoError(err)
 		err = k.SetFlatFee(ctx, contractAdminAcc.Address, types.FlatFee{
@@ -170,7 +171,7 @@ func (s *KeeperTestSuite) TestGRPC_EstimateTxFees() {
 		s.Require().EqualValues(minConsFee.Amount, fees.AmountOf("stake"))
 	})
 
-	s.Run("ok: gets estimated tx fees inclulding contract flat fee(same denom)", func() {
+	s.Run("ok: gets estimated tx fees including contract flat fee(same denom)", func() {
 		expectedFlatFee := sdk.NewInt64Coin("stake", 123)
 		contractAdminAcc := s.chain.GetAccount(0)
 		contractViewer := testutils.NewMockContractViewer()
@@ -180,6 +181,7 @@ func (s *KeeperTestSuite) TestGRPC_EstimateTxFees() {
 		err := k.SetContractMetadata(ctx, contractAdminAcc.Address, contractAddr, rewardsTypes.ContractMetadata{
 			ContractAddress: contractAddr.String(),
 			OwnerAddress:    contractAdminAcc.Address.String(),
+			RewardsAddress:  contractAdminAcc.Address.String(),
 		})
 		s.Require().NoError(err)
 		err = k.SetFlatFee(ctx, contractAdminAcc.Address, types.FlatFee{
@@ -289,6 +291,7 @@ func (s *KeeperTestSuite) TestGRPC_FlatFee() {
 		err := k.SetContractMetadata(ctx, contractAdminAcc.Address, contractAddr, rewardsTypes.ContractMetadata{
 			ContractAddress: contractAddr.String(),
 			OwnerAddress:    contractAdminAcc.Address.String(),
+			RewardsAddress:  contractAdminAcc.Address.String(),
 		})
 		s.Require().NoError(err)
 		err = k.SetFlatFee(ctx, contractAdminAcc.Address, types.FlatFee{


### PR DESCRIPTION
If rewards address is not set, prevent the contract owner from setting contract flat fee.
(Removing of flat fee is still allowed)

This is to prevent ante handler from panic-ing as it tries to create a rewards record in min_cons_fee ante handler