### PR TITLE
fix: fixing authz messages decoding issue in antehandlers 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Contains all the PRs that improved the code without changing the behaviours.
 ### Fixed
 
 - [#414](https://github.com/archway-network/archway/pull/414) - Preventing user from setting contract flat fee if rewards address is not set 
+- [#418](https://github.com/archway-network/archway/pull/418) - Fixing authz msg decoding in x/rewards antehandlers
 
 ## [v1.0.1]
 

--- a/x/rewards/ante/ante_utils.go
+++ b/x/rewards/ante/ante_utils.go
@@ -44,14 +44,14 @@ func GetContractFlatFees(ctx sdk.Context, rk RewardsKeeperExpected, codec codec.
 			}
 			return nil, true, nil
 		}
-	case *authz.MsgExec: // if msg is authz msg, unwrap the msg and check if any are wasmTypes.MsgExecuteContract
+	case *authz.MsgExec: // if msg is authz msg, get the unwrapped msgs and check if any are wasmTypes.MsgExecuteContract
 		{
-			for _, v := range msg.Msgs {
-				var wrappedMsg sdk.Msg
-				err := codec.UnpackAny(v, &wrappedMsg)
-				if err != nil {
-					return nil, false, sdkErrors.Wrapf(sdkErrors.ErrUnauthorized, "error decoding authz messages")
-				}
+			authzMsgs, err := msg.GetMessages()
+			if err != nil {
+				return nil, false, sdkErrors.Wrapf(sdkErrors.ErrUnauthorized, "error decoding authz messages")
+			}
+
+			for _, wrappedMsg := range authzMsgs {
 				cff, hasWasmMsgs, err := GetContractFlatFees(ctx, rk, codec, wrappedMsg)
 				if err != nil {
 					return nil, hasWasmMsgs, err


### PR DESCRIPTION
Closes: #417 

- Fixing the incorrect authz msg decoding in the x/rewards ante handlers.
- Using the nice helper func provided by x/authz to unwrap the msg instead of trying it explicitly 