### PR TITLE
chore: Easily run localnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 .vscode/
 
 dist/
+data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ Contains bug fixes.
 Contains all the PRs that improved the code without changing the behaviours. 
 -->
 
+## [Unreleased]
+
+### Added
+
+- [#419](https://github.com/archway-network/archway/pull/419) - Easily run localnet via make
+
+
 ## [v2.0.0]
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -257,3 +257,17 @@ check-vuln-deps:
 	go-mod-cache draw-deps clean build format \
 	test test-all test-build test-cover test-unit test-race \
 	test-sim-import-export \
+
+###############################################################################
+###                               Run Localnet                              ###
+###############################################################################
+
+# Run a new localnet
+run:
+	./scripts/localnet.sh 
+
+# Continue the existing localnet
+run-continue:
+	./scripts/localnet.sh continue
+
+.PHONY: localnet run-continue

--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -34,10 +34,10 @@ USER_MNEMONIC="any giant turtle pioneer frequent frown harvest ancient episode j
 GENESIS_COINS=1000000000000000000000000000000000000stake
 
 setup_chain () {
-  # Stop starsd if it is already running
+  # Stop archwayd if it is already running
   if pgrep -x "$BINARY" >/dev/null; then
       echo_error "Terminating $BINARY..."
-      killall starsd
+      killall archwayd
   fi
 
   # Remove previous data
@@ -45,7 +45,7 @@ setup_chain () {
   rm -rf $CHAIN_DIR/$CHAIN_ID
 
 
-  # Initialize starsd with "sg-localnet" chain id
+  # Initialize archwayd with "localnet-1" chain id
   echo_info "Initializing $CHAIN_ID..."
   if $BINARY --home $CHAIN_DIR/$CHAIN_ID init test --chain-id=$CHAIN_ID; then
     echo_success "Successfully initialized $CHAIN_ID"

--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+
+# Console log text colour
+red=`tput setaf 9`
+green=`tput setaf 10`
+blue=`tput setaf 12`
+reset=`tput sgr0`
+
+echo_info () {
+  echo "${blue}"
+  echo "$1"
+  echo "${reset}"
+}
+
+echo_error () {
+  echo "${red}"
+  echo "$1"
+  echo "${reset}"
+}
+
+echo_success () {
+  echo "${green}"
+  echo "$1"
+  echo "${reset}"
+}
+
+# Set localnet settings
+BINARY=./build/archwayd
+CHAIN_ID=localnet-1
+CHAIN_DIR=./data
+VALIDATOR_MNEMONIC="guard cream sadness conduct invite crumble clock pudding hole grit liar hotel maid produce squeeze return argue turtle know drive eight casino maze host"
+DEVELOPER_MNEMONIC="friend excite rough reopen cover wheel spoon convince island path clean monkey play snow number walnut pull lock shoot hurry dream divide concert discover"
+USER_MNEMONIC="any giant turtle pioneer frequent frown harvest ancient episode junior vocal rent shrimp icon idle echo suspect clean cage eternal sample post heavy enough"
+GENESIS_COINS=1000000000000000000000000000000000000stake
+
+setup_chain () {
+  # Stop starsd if it is already running
+  if pgrep -x "$BINARY" >/dev/null; then
+      echo_error "Terminating $BINARY..."
+      killall starsd
+  fi
+
+  # Remove previous data
+  echo_info "Removing previous chain data from $CHAIN_DIR/$CHAIN_ID..."
+  rm -rf $CHAIN_DIR/$CHAIN_ID
+
+
+  # Initialize starsd with "sg-localnet" chain id
+  echo_info "Initializing $CHAIN_ID..."
+  if $BINARY --home $CHAIN_DIR/$CHAIN_ID init test --chain-id=$CHAIN_ID; then
+    echo_success "Successfully initialized $CHAIN_ID"
+  else
+    echo_error "Failed to initialize $CHAIN_ID"
+  fi
+
+  # Modify config for development
+  config="$CHAIN_DIR/$CHAIN_ID/config/config.toml"
+  if [ "$(uname)" = "Linux" ]; then
+    sed -i "s/cors_allowed_origins = \[\]/cors_allowed_origins = [\"*\"]/g" $config
+  else
+    sed -i '' "s/cors_allowed_origins = \[\]/cors_allowed_origins = [\"*\"]/g" $config
+  fi
+  # modify genesis params for localnet ease of use
+  genesis="$CHAIN_DIR/$CHAIN_ID/config/genesis.json"
+  # x/gov params change
+  # reduce voting period to 2 minutes
+  contents="$(jq '.app_state.gov.voting_params.voting_period = "120s"' $genesis)" && echo "${contents}" >  $genesis
+  echo_info "Set x/gov voting period to 120 seconds"
+  # reduce minimum deposit amount to 10stake
+  contents="$(jq '.app_state.gov.deposit_params.min_deposit[0].amount = "10"' $genesis)" && echo "${contents}" >  $genesis
+  echo_info "Set x/gov proposal min deposit amount to 10 stake"
+  # reduce deposit period to 20seconds 
+  contents="$(jq '.app_state.gov.deposit_params.max_deposit_period = "20s"' $genesis)" && echo "${contents}" >  $genesis
+  echo_info "Set x/gov proposal max deposit period to 20 seconds"
+
+
+  # Adding users
+  echo_info "Adding genesis accounts..."
+  echo_info "1. validator"
+  echo $VALIDATOR_MNEMONIC | $BINARY --home $CHAIN_DIR/$CHAIN_ID keys add validator --recover --keyring-backend test
+  $BINARY --home $CHAIN_DIR/$CHAIN_ID add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAIN_ID keys show validator --keyring-backend test -a) $GENESIS_COINS
+  echo_info "2. developer"
+  echo $DEVELOPER_MNEMONIC | $BINARY --home $CHAIN_DIR/$CHAIN_ID keys add developer --recover --keyring-backend test
+  $BINARY --home $CHAIN_DIR/$CHAIN_ID add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAIN_ID keys show developer --keyring-backend test -a) $GENESIS_COINS
+  echo_info "3. user"
+  echo $USER_MNEMONIC | $BINARY --home $CHAIN_DIR/$CHAIN_ID keys add user --recover --keyring-backend test
+  $BINARY --home $CHAIN_DIR/$CHAIN_ID add-genesis-account $($BINARY --home $CHAIN_DIR/$CHAIN_ID keys show user --keyring-backend test -a) $GENESIS_COINS
+
+
+  # Creating gentx
+  echo_info "Creating gentx for validator..."
+  $BINARY --home $CHAIN_DIR/$CHAIN_ID gentx validator 100000000000000000000000stake --chain-id $CHAIN_ID --fees 950000000000000000000stake --keyring-backend test
+
+
+  # Collecting gentx
+  echo_info "Collecting gentx..."
+  if $BINARY --home $CHAIN_DIR/$CHAIN_ID collect-gentxs; then
+    echo_success "Successfully collected genesis txs into genesis.json"
+  else
+    echo_error "Failed to collect genesis txs"
+  fi
+
+
+  # Validating genesis
+  echo_info "Validating genesis..."
+  if $BINARY --home $CHAIN_DIR/$CHAIN_ID validate-genesis; then
+    echo_success "Successfully validated genesis"
+  else
+    echo_error "Failed to validate genesis"
+  fi
+}
+ 
+if [ "$1" != "continue" ] ;then
+  setup_chain  
+fi
+
+# Starting chain
+echo_info "Starting chain..."
+$BINARY --home $CHAIN_DIR/$CHAIN_ID start


### PR DESCRIPTION
This PR adds two new make commands
1. `make run`  - This will bootstrap a new localnet on the dev machine
2. `make run-continue` - This will continue running an existing localnet on the dev machine 


The localnet has the chain-id `localnet-1` and has been configured with three accounts on startup. The localnet setup also customizes the governance parameters to be shorter duration for easier testing.