### PR TITLE
chore: update go version to 1.20

### DIFF
--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -18,11 +18,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
-
-      - uses: actions/checkout@v3
+          go-version-file: go.mod
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v3
         with:
-          go-version: ~1.19
+          go-version-file: go.mod
       - name: Setup Golang caches
         uses: actions/cache@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ Contains bug fixes.
 Contains all the PRs that improved the code without changing the behaviours.
 -->
 
+## [Unreleased]
+
+### Changed
+
+- [#428](https://github.com/archway-network/archway/pull/428) - Update go version to 1.20
+
 ## [v3.0.0]
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/archway-network/archway
 
-go 1.19
+go 1.20
 
 require (
 	github.com/CosmWasm/cosmwasm-go v0.5.1-0.20220822092235-974247a04ac7


### PR DESCRIPTION
- Updating go version in go.mod to 1.20
- Updating Github workflows to use go version from go mod file instead of hardcoded version 