### PR TITLE
chore: Post release maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ Contains bug fixes.
 Contains all the PRs that improved the code without changing the behaviours.
 -->
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Improvements
+
 ## [v4.0.0]
 
 ### Added

--- a/app/app_upgrades.go
+++ b/app/app_upgrades.go
@@ -11,6 +11,7 @@ import (
 	upgrade2_0_0 "github.com/archway-network/archway/app/upgrades/2_0_0"
 	upgrade3_0_0 "github.com/archway-network/archway/app/upgrades/3_0_0"
 	upgrade4_0_0 "github.com/archway-network/archway/app/upgrades/4_0_0"
+	upgradelatest "github.com/archway-network/archway/app/upgrades/latest"
 )
 
 // UPGRADES
@@ -21,6 +22,8 @@ var Upgrades = []upgrades.Upgrade{
 	upgrade2_0_0.Upgrade,      // v2.0.0
 	upgrade3_0_0.Upgrade,      // v3.0.0
 	upgrade4_0_0.Upgrade,      // v4.0.0
+
+	upgradelatest.Upgrade, // latest - This upgrade handler is used for all the current changes to the protocol
 }
 
 func (app *ArchwayApp) setupUpgrades() {

--- a/app/upgrades/latest/upgrades.go
+++ b/app/upgrades/latest/upgrades.go
@@ -1,0 +1,24 @@
+package upgradelatest
+
+import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	"github.com/archway-network/archway/app/upgrades"
+)
+
+// This upgrade handler is used for all the current changes to the protocol
+
+const Name = "latest"
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName: Name,
+	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator) upgradetypes.UpgradeHandler {
+		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			return mm.RunMigrations(ctx, cfg, fromVM)
+		}
+	},
+	StoreUpgrades: storetypes.StoreUpgrades{},
+}

--- a/interchaintest/setup.go
+++ b/interchaintest/setup.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	initialVersion = "v3.0.0" // The last release of the chain. The one the mainnet is running on
-	upgradeName    = "v4.0.0" // The next upgrade name. Should match the upgrade handler.
+	initialVersion = "v4.0.0" // The last release of the chain. The one the mainnet is running on
+	upgradeName    = "latest" // The next upgrade name. Should match the upgrade handler.
 	chainName      = "archway"
 )
 


### PR DESCRIPTION
Now that we have a chain upgrade test https://github.com/archway-network/archway/pull/430, this forces our repository to always have an active upgrade handler. With this PR, I propose that we have a `latest` upgrade handler where all the upcoming upgrade logic goes into. This way any missing upgrade handling will be caught immediately by the developer who was working on the feature, as opposed to whoever adds in the upgrade handler prior to release. Whenever we decide to cut a release, we can rename the upgrade handler from `latest` to `v5.0.0` or something like that.

One overhead with this to keep track of is that once we tag a release, we would have to do a maintenance PR like this which creates a new upgrade handler post release.
