### PR TITLE
chore: retagging with v4.0.2 to prevent dual tagging of same commit 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,17 @@ Contains bug fixes.
 Contains all the PRs that improved the code without changing the behaviours.
 -->
 
+## [v4.0.2]
+
+### Changed
+
+- - [#440](https://github.com/archway-network/archway/pull/440) - Retagging with v4.0.2 to prevent dual tagging of same commit and same tag name
+
 ## [v4.0.1]
 
 ### Fixed
 
-- [#437](https://github.com/archway-network/archway/pull/437) - adding upgrade handler with missing burn permissions for feecollector account
+- [#437](https://github.com/archway-network/archway/pull/437) - Adding upgrade handler with missing burn permissions for feecollector account
 
 ## [v4.0.0]
 

--- a/app/app_upgrades.go
+++ b/app/app_upgrades.go
@@ -11,7 +11,7 @@ import (
 	upgrade2_0_0 "github.com/archway-network/archway/app/upgrades/2_0_0"
 	upgrade3_0_0 "github.com/archway-network/archway/app/upgrades/3_0_0"
 	upgrade4_0_0 "github.com/archway-network/archway/app/upgrades/4_0_0"
-	upgrade4_0_1 "github.com/archway-network/archway/app/upgrades/4_0_1"
+	upgrade4_0_2 "github.com/archway-network/archway/app/upgrades/4_0_2"
 )
 
 // UPGRADES
@@ -22,7 +22,7 @@ var Upgrades = []upgrades.Upgrade{
 	upgrade2_0_0.Upgrade,      // v2.0.0
 	upgrade3_0_0.Upgrade,      // v3.0.0
 	upgrade4_0_0.Upgrade,      // v4.0.0
-	upgrade4_0_1.Upgrade,      // v4.0.1
+	upgrade4_0_2.Upgrade,      // v4.0.2
 }
 
 func (app *ArchwayApp) setupUpgrades() {

--- a/app/upgrades/4_0_2/upgrades.go
+++ b/app/upgrades/4_0_2/upgrades.go
@@ -1,4 +1,4 @@
-package upgrade4_0_1
+package upgrade4_0_2
 
 import (
 	"fmt"
@@ -13,7 +13,7 @@ import (
 	"github.com/archway-network/archway/app/upgrades"
 )
 
-const Name = "v4.0.1"
+const Name = "v4.0.2"
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName: Name,

--- a/app/upgrades/4_0_2/upgrades_test.go
+++ b/app/upgrades/4_0_2/upgrades_test.go
@@ -1,4 +1,4 @@
-package upgrade4_0_1_test
+package upgrade4_0_2_test
 
 import (
 	"fmt"
@@ -78,7 +78,7 @@ func (suite *UpgradeTestSuite) TestUpgrade() {
 			tc.pre_upgrade()
 
 			ctx := suite.archway.GetContext().WithBlockHeight(dummyUpgradeHeight - 1)
-			plan := upgradetypes.Plan{Name: "v4.0.1", Height: dummyUpgradeHeight}
+			plan := upgradetypes.Plan{Name: "v4.0.2", Height: dummyUpgradeHeight}
 			upgradekeeper := suite.archway.GetApp().UpgradeKeeper
 			err := upgradekeeper.ScheduleUpgrade(ctx, plan)
 			suite.Require().NoError(err)

--- a/interchaintest/chain_v402_upgrade_test.go
+++ b/interchaintest/chain_v402_upgrade_test.go
@@ -17,7 +17,7 @@ import (
 // To run this test, you will need the following heighliner images
 // heighliner build --org archway-network --repo archway --dockerfile cosmos --build-target "make build" --build-env "BUILD_TAGS=muslc" --binaries "build/archwayd" --git-ref v2.0.0 --tag v2.0.0 -c archway
 // heighliner build --org archway-network --repo archway --dockerfile cosmos --build-target "make build" --build-env "BUILD_TAGS=muslc" --binaries "build/archwayd" --git-ref v4.0.0 --tag v4.0.0 -c archway
-// heighliner build --org archway-network --repo archway --dockerfile cosmos --build-target "make build" --build-env "BUILD_TAGS=muslc" --binaries "build/archwayd" --git-ref v4.0.1 --tag v4.0.1 -c archway
+// heighliner build --org archway-network --repo archway --dockerfile cosmos --build-target "make build" --build-env "BUILD_TAGS=muslc" --binaries "build/archwayd" --git-ref v4.0.2 --tag v4.0.2 -c archway
 func TestFeeCollectorBurnChainUpgrade(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping in short mode")
@@ -37,7 +37,7 @@ func TestFeeCollectorBurnChainUpgrade(t *testing.T) {
 	queryRes2 := getModuleAccount(t, ctx, authtypes.FeeCollectorName, archwayChain)
 	require.Len(t, queryRes2.Account.Permissions, 0, "feecollector should not have burn permissions in v2.0.0")
 
-	// Upgrading to v4.0.0 => Not directly upgrading to v4.0.1 to simulate how things went on constantine.
+	// Upgrading to v4.0.0 => Not directly upgrading to v4.0.2 to simulate how things went on constantine.
 	haltHeight := submitUpgradeProposalAndVote(t, ctx, "v4.0.0", archwayChain, chainUser)
 	height, err := archwayChain.Height(ctx)
 	require.NoError(t, err, "cound not fetch height before upgrade")
@@ -59,8 +59,8 @@ func TestFeeCollectorBurnChainUpgrade(t *testing.T) {
 	queryRes4 := getModuleAccount(t, ctx, authtypes.FeeCollectorName, archwayChain)
 	require.Len(t, queryRes4.Account.Permissions, 0, "feecollector should not have burn permissions in v4.0.0")
 
-	// Upgrading to v4.0.1
-	haltHeight = submitUpgradeProposalAndVote(t, ctx, "v4.0.1", archwayChain, chainUser)
+	// Upgrading to v4.0.2
+	haltHeight = submitUpgradeProposalAndVote(t, ctx, "v4.0.2", archwayChain, chainUser)
 	height, err = archwayChain.Height(ctx)
 	require.NoError(t, err, "cound not fetch height before upgrade")
 	testutil.WaitForBlocks(timeoutCtx, int(haltHeight-height)+1, archwayChain)
@@ -69,7 +69,7 @@ func TestFeeCollectorBurnChainUpgrade(t *testing.T) {
 	require.Equal(t, int(haltHeight), int(height), "height is not equal to halt height")
 	err = archwayChain.StopAllNodes(ctx)
 	require.NoError(t, err, "could not stop node(s)")
-	archwayChain.UpgradeVersion(ctx, client, chainName, "v4.0.1")
+	archwayChain.UpgradeVersion(ctx, client, chainName, "v4.0.2")
 	err = archwayChain.StartAllNodes(ctx)
 	require.NoError(t, err, "could not start upgraded node(s)")
 	timeoutCtx, timeoutCtxCancel = context.WithTimeout(ctx, time.Second*45)
@@ -77,10 +77,10 @@ func TestFeeCollectorBurnChainUpgrade(t *testing.T) {
 	err = testutil.WaitForBlocks(timeoutCtx, int(blocksAfterUpgrade), archwayChain)
 	require.NoError(t, err, "chain did not produce blocks after upgrade")
 
-	// Ensuring feecollector HAS burn permissions in v4.0.1
+	// Ensuring feecollector HAS burn permissions in v4.0.2
 	queryRes401 := getModuleAccount(t, ctx, authtypes.FeeCollectorName, archwayChain)
-	require.Len(t, queryRes401.Account.Permissions, 1, "feecollector should have one permissions in v4.0.1")
-	require.Equal(t, authtypes.Burner, queryRes401.Account.Permissions[0], "feecollector should have burn permissions in v4.0.1")
+	require.Len(t, queryRes401.Account.Permissions, 1, "feecollector should have one permissions in v4.0.2")
+	require.Equal(t, authtypes.Burner, queryRes401.Account.Permissions[0], "feecollector should have burn permissions in v4.0.2")
 }
 
 func getModuleAccount(t *testing.T, ctx context.Context, moduleAccountName string, archwayChain *cosmos.CosmosChain) QueryModuleAccountResponse {

--- a/interchaintest/setup.go
+++ b/interchaintest/setup.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	initialVersion = "v4.0.0" // The last release of the chain. The one the mainnet is running on
-	upgradeName    = "v4.0.1" // The next upgrade name. Should match the upgrade handler.
+	upgradeName    = "v4.0.2" // The next upgrade name. Should match the upgrade handler.
 	chainName      = "archway"
 )
 

--- a/interchaintest/setup.go
+++ b/interchaintest/setup.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	initialVersion = "v4.0.0" // The last release of the chain. The one the mainnet is running on
+	initialVersion = "v4.0.1" // The last release of the chain. The one the mainnet is running on
 	upgradeName    = "v4.0.2" // The next upgrade name. Should match the upgrade handler.
 	chainName      = "archway"
 )


### PR DESCRIPTION
- all references to v4.0.1 in the code renamed to v4.0.2 (this is because v4.0.1-rc.1 tag and v4.0.1 tag existing together make goreleaser's life a bit complicated)