### PR TITLE
chore: Post v4.0.2 release maintenance 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,22 @@ Contains bug fixes.
 Contains all the PRs that improved the code without changing the behaviours.
 -->
 
-## [v4.0.2]
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Improvements
+
+
+## [v4.0.2](https://github.com/archway-network/archway/releases/tag/v4.0.2)
 
 ### Changed
 
@@ -38,13 +53,13 @@ Contains all the PRs that improved the code without changing the behaviours.
 
 - [#441](https://github.com/archway-network/archway/pull/441) - go-releaser must order tags with create date, when there are multiple tags on the same commit
 
-## [v4.0.1]
+## [v4.0.1](https://github.com/archway-network/archway/releases/tag/v4.0.1)
 
 ### Fixed
 
 - [#437](https://github.com/archway-network/archway/pull/437) - Adding upgrade handler with missing burn permissions for feecollector account
 
-## [v4.0.0]
+## [v4.0.0](https://github.com/archway-network/archway/releases/tag/v4.0.0)
 
 ### Added
 
@@ -55,7 +70,7 @@ Contains all the PRs that improved the code without changing the behaviours.
 
 - [#428](https://github.com/archway-network/archway/pull/428) - Update go version to 1.20
 
-## [v3.0.0]
+## [v3.0.0](https://github.com/archway-network/archway/releases/tag/v3.0.0)
 
 ### Fixed
 
@@ -69,7 +84,7 @@ Contains all the PRs that improved the code without changing the behaviours.
 - [#423](https://github.com/archway-network/archway/pull/423) - Update release docs
 - [#425](https://github.com/archway-network/archway/pull/425) - Update ADR 004 - Contract Premiums
 
-## [v2.0.0]
+## [v2.0.0](https://github.com/archway-network/archway/releases/tag/v2.0.0)
 
 ### Added
 
@@ -80,30 +95,30 @@ Contains all the PRs that improved the code without changing the behaviours.
 - [#414](https://github.com/archway-network/archway/pull/414) - Prevent user from setting contract flat fee if rewards address is not set
 - [#418](https://github.com/archway-network/archway/pull/418) - Fix authz msg decoding in x/rewards antehandlers
 
-## [v1.0.1]
+## [v1.0.1](https://github.com/archway-network/archway/releases/tag/v1.0.1)
 
 - [#411](https://github.com/archway-network/archway/pull/411) - Update repository readme with correct docker containers.
 - [#413](https://github.com/archway-network/archway/pull/413) - Fix incorrect gas estimation when running with `--dry-run` flag
 
-## [v1.0.0]
+## [v1.0.0](https://github.com/archway-network/archway/releases/tag/v1.0.0)
 
 Archway Network - Capture the value you create!
 
 
-## [v1.0.0-rc.4]
+## [v1.0.0-rc.4](https://github.com/archway-network/archway/releases/tag/v1.0.0-rc.4)
 
 ### Added
 
 - [#409](https://github.com/archway-network/archway/pull/409) - Add cosmwasm_1_1,cosmwasm_1_2 Cosmwasm capabilities
 
 
-## [v1.0.0-rc.3]
+## [v1.0.0-rc.3](https://github.com/archway-network/archway/releases/tag/v1.0.0-rc.3)
 
 ### Removed
 
 - [#408](https://github.com/archway-network/archway/pull/408) - Remove genesis msg logging as it impacts network start up performance.
 
-## [v1.0.0-rc.2]
+## [v1.0.0-rc.2](https://github.com/archway-network/archway/releases/tag/v1.0.0-rc.2)
 
 ### Fixes
 
@@ -113,13 +128,13 @@ Archway Network - Capture the value you create!
 - [#404](https://github.com/archway-network/archway/pull/403) - Fix typo in rewards query cli
 - [#406](https://github.com/archway-network/archway/pull/406) - Add upgrade hanlder for v0.6.0 back to prevent downgrade check from panic / consensus failure;
 
-## [v1.0.0-rc.1]
+## [v1.0.0-rc.1](https://github.com/archway-network/archway/releases/tag/v1.0.0-rc.1)
 
 ### Removed
 
 - [#399](https://github.com/archway-network/archway/pull/399) - Remove the upgrade handler for v1 release
 
-## [v0.6.0]
+## [v0.6.0](https://github.com/archway-network/archway/releases/tag/v0.6.0)
 
 ### Added
 
@@ -143,13 +158,13 @@ Archway Network - Capture the value you create!
 - [#393](https://github.com/archway-network/archway/pull/393) - Add audit remediations
 - [#397](https://github.com/archway-network/archway/pull/397) - Fix map iteration
 
-## [v0.5.2]
+## [v0.5.2](https://github.com/archway-network/archway/releases/tag/v0.5.2)
 
 ### Fixed
 
 - [#382](https://github.com/archway-network/archway/pull/382) - Adjust default power reduction
 
-## [v0.5.0]
+## [v0.5.0](https://github.com/archway-network/archway/releases/tag/v0.5.0)
 
 ### Breaking Changes
 
@@ -206,19 +221,19 @@ Archway Network - Capture the value you create!
 
 - [#342](https://github.com/archway-network/archway/pull/342) - updated the contract premium ADR docs to elaborate on difference between using Contract Premiums and using x/wasmd funds
 
-## [v0.4.0]
+## [v0.4.0](https://github.com/archway-network/archway/releases/tag/v0.4.0)
 
 ### Fixed
 
 - [#338](https://github.com/archway-network/archway/pull/338) - fixed issue where contract premium was not completly being sent to the rewards address
 
-## [v0.3.1]
+## [v0.3.1](https://github.com/archway-network/archway/releases/tag/v0.3.1)
 
 ### Fixed
 
 - [#335](https://github.com/archway-network/archway/pull/335) - fixed `EstimateTxFees` erroring when minConsFee and contract premium are same denom
 
-## [v0.3.0]
+## [v0.3.0](https://github.com/archway-network/archway/releases/tag/v0.3.0)
 
 ### Added
 
@@ -233,7 +248,7 @@ Archway Network - Capture the value you create!
 - [#271](https://github.com/archway-network/archway/pull/271) - update the x/rewards/min_cons_fee antehandler to check for contract flat fees
 - [#275](https://github.com/archway-network/archway/pull/275) - update the x/rewards/genesis to import/export for contract flat fees
 
-## [v0.1.0]
+## [v0.1.0](https://github.com/archway-network/archway/releases/tag/v0.1.0)
 
 ### Added
 
@@ -289,7 +304,7 @@ Archway Network - Capture the value you create!
 - [#247](https://github.com/archway-network/archway/pull/247) - fix Dockerfile libwasm VM dependencies
 - [#249](https://github.com/archway-network/archway/pull/249) - add go releaser, fill changelog history
 
-## v0.0.5
+## [v0.0.5](https://github.com/archway-network/archway/releases/tag/v0.0.5)
 
 ### Breaking Changes
 
@@ -300,7 +315,7 @@ Archway Network - Capture the value you create!
 - Fix logs printing total contract rewards instead of gas rebate reward.
 - Replace info logs for debug logs.
 
-## v0.0.4
+## [v0.0.4](https://github.com/archway-network/archway/releases/tag/v0.0.4)
 
 ### Breaking Changes
 

--- a/app/app_upgrades.go
+++ b/app/app_upgrades.go
@@ -12,6 +12,7 @@ import (
 	upgrade3_0_0 "github.com/archway-network/archway/app/upgrades/3_0_0"
 	upgrade4_0_0 "github.com/archway-network/archway/app/upgrades/4_0_0"
 	upgrade4_0_2 "github.com/archway-network/archway/app/upgrades/4_0_2"
+	upgradelatest "github.com/archway-network/archway/app/upgrades/latest"
 )
 
 // UPGRADES
@@ -23,6 +24,8 @@ var Upgrades = []upgrades.Upgrade{
 	upgrade3_0_0.Upgrade,      // v3.0.0
 	upgrade4_0_0.Upgrade,      // v4.0.0
 	upgrade4_0_2.Upgrade,      // v4.0.2
+
+	upgradelatest.Upgrade, // latest - This upgrade handler is used for all the current changes to the protocol
 }
 
 func (app *ArchwayApp) setupUpgrades() {

--- a/app/upgrades/latest/upgrades.go
+++ b/app/upgrades/latest/upgrades.go
@@ -1,0 +1,25 @@
+package upgradelatest
+
+import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	"github.com/archway-network/archway/app/upgrades"
+)
+
+// This upgrade handler is used for all the current changes to the protocol
+
+const Name = "latest"
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName: Name,
+	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, accountKeeper keeper.AccountKeeper) upgradetypes.UpgradeHandler {
+		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			return mm.RunMigrations(ctx, cfg, fromVM)
+		}
+	},
+	StoreUpgrades: storetypes.StoreUpgrades{},
+}

--- a/interchaintest/setup.go
+++ b/interchaintest/setup.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	initialVersion = "v4.0.1" // The last release of the chain. The one the mainnet is running on
-	upgradeName    = "v4.0.2" // The next upgrade name. Should match the upgrade handler.
+	initialVersion = "v4.0.2" // The last release of the chain. The one the mainnet is running on
+	upgradeName    = "latest" // The next upgrade name. Should match the upgrade handler.
 	chainName      = "archway"
 )
 


### PR DESCRIPTION
- Adding `latest` upgrade handler for future dev work
- Adding release links to the changelog