### PR TITLE
fix: typo fix in goreleaser name template

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -230,7 +230,7 @@ docker_manifests:
     image_templates:
       - 'ghcr.io/archway-network/{{ .ProjectName }}d:{{if eq .Env.RELEASE "true"}}v{{ .Version }}-amd64{{else}}{{ .ShortCommit }}-amd64{{end}}'
       - 'ghcr.io/archway-network/{{ .ProjectName }}d:{{if eq .Env.RELEASE "true"}}v{{ .Version }}-arm64v8{{else}}{{ .ShortCommit }}-arm64v8{{end}}'
-  - name_template: 'ghcr.io/archway-network/{{ .ProjectName }}d-dev{{if eq .Env.RELEASE "true" }}v{{ .Version }}{{else}}{{ .ShortCommit }}{{end}}'
+  - name_template: 'ghcr.io/archway-network/{{ .ProjectName }}d-dev:{{if eq .Env.RELEASE "true" }}v{{ .Version }}{{else}}{{ .ShortCommit }}{{end}}'
     image_templates:
       - 'ghcr.io/archway-network/{{ .ProjectName }}d-dev:{{if eq .Env.RELEASE "true"}}v{{ .Version }}{{else}}{{ .ShortCommit }}{{end}}-amd64'
       - 'ghcr.io/archway-network/{{ .ProjectName }}d-dev:{{if eq .Env.RELEASE "true"}}v{{ .Version }}{{else}}{{ .ShortCommit }}{{end}}-arm64v8'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Contains all the PRs that improved the code without changing the behaviours.
 
 ### Added
 
-- [#439](https://github.com/archway-network/archway/pull/439) - adding containerized localnet
+- [#439](https://github.com/archway-network/archway/pull/439) - Adding containerized localnet
 - [#445](https://github.com/archway-network/archway/pull/445) - Adding Archway logo and version number to upgrade logs
 
 ### Changed


### PR DESCRIPTION
fixes a goreleasers missing image manifest `:` which results failed image creation