### PR TITLE
fix: goreleaser dev image tag

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -196,7 +196,7 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile.dev
     image_templates:
-      - 'ghcr.io/archway-network/{{ .ProjectName }}d-dev{{if eq .Env.RELEASE "true"}}v{{ .Version }}{{else}}{{ .ShortCommit }}{{end}}-amd64'
+      - 'ghcr.io/archway-network/{{ .ProjectName }}d-dev:{{if eq .Env.RELEASE "true"}}v{{ .Version }}{{else}}{{ .ShortCommit }}{{end}}-amd64'
     build_flag_templates:
       - "--pull"
       - "--platform=linux/amd64"
@@ -213,7 +213,7 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile.dev
     image_templates:
-      - 'ghcr.io/archway-network/{{ .ProjectName }}d-dev{{if eq .Env.RELEASE "true"}}v{{ .Version }}{{else}}{{ .ShortCommit }}{{end}}-arm64v8'
+      - 'ghcr.io/archway-network/{{ .ProjectName }}d-dev:{{if eq .Env.RELEASE "true"}}v{{ .Version }}{{else}}{{ .ShortCommit }}{{end}}-arm64v8'
     build_flag_templates:
       - "--pull"
       - "--platform=linux/arm64"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ Contains all the PRs that improved the code without changing the behaviours.
 
 ### Deprecated
 
-- [#439](https://github.com/archway-network/archway/pull/439) - renaming `debug` image to `dev`
+- [#439](https://github.com/archway-network/archway/pull/439) - Renaming `debug` image to `dev`
 
 ### Removed
 


### PR DESCRIPTION
Fixes the goreleaser image tag, missin `:` 