### PR TITLE
chore: remove deprecated appmodule routes

### DIFF
--- a/x/genmsg/module.go
+++ b/x/genmsg/module.go
@@ -75,20 +75,6 @@ func (a AppModule) GetQueryCmd() *cobra.Command { return &cobra.Command{Use: Mod
 
 func (a AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 
-func (a AppModule) Route() sdk.Route {
-	return sdk.NewRoute(ModuleName, func(ctx sdk.Context, msg sdk.Msg) (*sdk.Result, error) {
-		return nil, fmt.Errorf("do not use me")
-	})
-}
-
-func (a AppModule) QuerierRoute() string { return ModuleName }
-
-func (a AppModule) LegacyQuerierHandler(_ *codec.LegacyAmino) sdk.Querier {
-	return func(ctx sdk.Context, path []string, req abci.RequestQuery) ([]byte, error) {
-		return nil, fmt.Errorf("do not use me")
-	}
-}
-
 func (a AppModule) RegisterServices(_ module.Configurator) {}
 
 func (a AppModule) ConsensusVersion() uint64 { return 0 }

--- a/x/rewards/module.go
+++ b/x/rewards/module.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -105,20 +104,6 @@ func (a AppModule) RegisterInvariants(ir sdk.InvariantRegistry) {
 	keeper.RegisterInvariants(ir, a.keeper)
 }
 
-// Route returns the message routing key for the module.
-// Deprecated.
-func (AppModule) Route() sdk.Route { return sdk.Route{} }
-
-// QuerierRoute returns the module's querier route name.
-func (a AppModule) QuerierRoute() string {
-	return types.QuerierRoute
-}
-
-// LegacyQuerierHandler returns the staking module sdk.Querier.
-func (a AppModule) LegacyQuerierHandler(_ *codec.LegacyAmino) sdk.Querier {
-	return nil
-}
-
 // RegisterServices registers the module services.
 func (a AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServer(a.keeper))
@@ -162,11 +147,6 @@ func (a AppModule) GenerateGenesisState(input *module.SimulationState) {}
 // ProposalContents doesn't return any content functions for governance proposals.
 func (a AppModule) ProposalContents(_ module.SimulationState) []simTypes.WeightedProposalContent {
 	return []simTypes.WeightedProposalContent{}
-}
-
-// RandomizedParams creates randomized param changes for the simulator.
-func (a AppModule) RandomizedParams(r *rand.Rand) []simTypes.ParamChange {
-	return []simTypes.ParamChange{}
 }
 
 // RegisterStoreDecoder registers a decoder for the module's types.

--- a/x/tracking/module.go
+++ b/x/tracking/module.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -100,20 +99,6 @@ func NewAppModule(cdc codec.Codec, keeper keeper.Keeper) AppModule {
 // RegisterInvariants registers the module invariants.
 func (a AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 
-// Route returns the message routing key for the module.
-// Deprecated.
-func (AppModule) Route() sdk.Route { return sdk.Route{} }
-
-// QuerierRoute returns the module's querier route name.
-func (a AppModule) QuerierRoute() string {
-	return types.QuerierRoute
-}
-
-// LegacyQuerierHandler returns the staking module sdk.Querier.
-func (a AppModule) LegacyQuerierHandler(_ *codec.LegacyAmino) sdk.Querier {
-	return nil
-}
-
 // RegisterServices registers the module services.
 func (a AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServer(a.keeper))
@@ -156,11 +141,6 @@ func (a AppModule) GenerateGenesisState(input *module.SimulationState) {}
 // ProposalContents doesn't return any content functions for governance proposals.
 func (a AppModule) ProposalContents(_ module.SimulationState) []simTypes.WeightedProposalContent {
 	return []simTypes.WeightedProposalContent{}
-}
-
-// RandomizedParams creates randomized param changes for the simulator.
-func (a AppModule) RandomizedParams(r *rand.Rand) []simTypes.ParamChange {
-	return []simTypes.ParamChange{}
 }
 
 // RegisterStoreDecoder registers a decoder for the module's types.


### PR DESCRIPTION
This PR removes the following deprecated routes from the appmodule of all the modules x/genmsgs, x/rewards, x/tracking
- Route
- QuerierRoute
- LegacyQuerierHandler