### PR TITLE
chore: updating app wiring

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -980,7 +980,6 @@ func BlockedAddresses() map[string]bool {
 
 func GetGovProposalHandlers() []govclient.ProposalHandler {
 	var govProposalHandlers []govclient.ProposalHandler
-	// this line is used by starport scaffolding # stargate/app/govProposalHandlers
 
 	govProposalHandlers = append(govProposalHandlers,
 		paramsclient.ProposalHandler,
@@ -988,7 +987,6 @@ func GetGovProposalHandlers() []govclient.ProposalHandler {
 		upgradeclient.LegacyCancelProposalHandler,
 		ibcclientclient.UpdateClientProposalHandler,
 		ibcclientclient.UpgradeProposalHandler,
-		// this line is used by starport scaffolding # stargate/app/govProposalHandler
 	)
 
 	return govProposalHandlers

--- a/app/app.go
+++ b/app/app.go
@@ -21,6 +21,7 @@ import (
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
+	nodeservice "github.com/cosmos/cosmos-sdk/client/grpc/node"
 	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
@@ -940,6 +941,11 @@ func (app *ArchwayApp) RegisterTxService(clientCtx client.Context) {
 // RegisterTendermintService implements the Application.RegisterTendermintService method.
 func (app *ArchwayApp) RegisterTendermintService(clientCtx client.Context) {
 	tmservice.RegisterTendermintService(app.BaseApp.GRPCQueryRouter(), clientCtx, app.interfaceRegistry)
+}
+
+// RegisterNodeService implements the Application.RegisterNodeService method.
+func (app *ArchwayApp) RegisterNodeService(clientCtx client.Context) {
+	nodeservice.RegisterNodeService(clientCtx, app.GRPCQueryRouter())
 }
 
 func (app *ArchwayApp) AppCodec() codec.Codec {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -36,7 +36,7 @@ func TestArchwaydExport(t *testing.T) {
 
 	// Making a new app object with the db, so that initchain hasn't been called
 	newGapp := NewArchwayApp(log.NewTMLogger(log.NewSyncWriter(os.Stdout)), db, nil, true, map[int64]bool{}, DefaultNodeHome, 0, MakeEncodingConfig(), wasm.EnableAllProposals, EmptyBaseAppOptions{}, emptyWasmOpts)
-	_, err = newGapp.ExportAppStateAndValidators(false, []string{})
+	_, err = newGapp.ExportAppStateAndValidators(false, []string{}, []string{})
 	require.NoError(t, err, "ExportAppStateAndValidators should not have an error")
 }
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -21,7 +21,7 @@ func TestArchwaydExport(t *testing.T) {
 	db := db.NewMemDB()
 	gapp := NewArchwayApp(log.NewTMLogger(log.NewSyncWriter(os.Stdout)), db, nil, true, map[int64]bool{}, DefaultNodeHome, 0, MakeEncodingConfig(), wasm.EnableAllProposals, EmptyBaseAppOptions{}, emptyWasmOpts)
 
-	genesisState := NewDefaultGenesisState()
+	genesisState := NewDefaultGenesisState(gapp.AppCodec())
 	stateBytes, err := json.MarshalIndent(genesisState, "", "  ")
 	require.NoError(t, err)
 

--- a/app/export.go
+++ b/app/export.go
@@ -16,7 +16,7 @@ import (
 // ExportAppStateAndValidators exports the state of the application for a genesis
 // file.
 func (app *ArchwayApp) ExportAppStateAndValidators(
-	forZeroHeight bool, jailAllowedAddrs []string,
+	forZeroHeight bool, jailAllowedAddrs []string, modulesToExport []string,
 ) (servertypes.ExportedApp, error) {
 	// as if they could withdraw from the start of the next block
 	ctx := app.NewContext(true, tmproto.Header{Height: app.LastBlockHeight()})
@@ -29,13 +29,13 @@ func (app *ArchwayApp) ExportAppStateAndValidators(
 		app.prepForZeroHeightGenesis(ctx, jailAllowedAddrs)
 	}
 
-	genState := app.mm.ExportGenesis(ctx, app.appCodec)
+	genState := app.mm.ExportGenesisForModules(ctx, app.appCodec, modulesToExport)
 	appState, err := json.MarshalIndent(genState, "", "  ")
 	if err != nil {
 		return servertypes.ExportedApp{}, err
 	}
 
-	validators, err := staking.WriteValidators(ctx, app.StakingKeeper)
+	validators, err := staking.WriteValidators(ctx, &app.StakingKeeper)
 	return servertypes.ExportedApp{
 		AppState:        appState,
 		Validators:      validators,

--- a/app/genesis.go
+++ b/app/genesis.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"encoding/json"
+
+	"github.com/cosmos/cosmos-sdk/codec"
 )
 
 // GenesisState The genesis state of the blockchain is represented here as a map of raw json
@@ -14,7 +16,6 @@ import (
 type GenesisState map[string]json.RawMessage
 
 // NewDefaultGenesisState generates the default state for the application.
-func NewDefaultGenesisState() GenesisState {
-	encodingConfig := MakeEncodingConfig()
-	return ModuleBasics.DefaultGenesis(encodingConfig.Marshaler)
+func NewDefaultGenesisState(cdc codec.JSONCodec) GenesisState {
+	return ModuleBasics.DefaultGenesis(cdc)
 }

--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -120,7 +120,7 @@ func TestAppImportExport(t *testing.T) {
 		t,
 		os.Stdout,
 		app.BaseApp,
-		sims.AppStateFn(app.AppCodec(), app.SimulationManager(), app.DefaultGenesis()),
+		sims.AppStateFn(app.AppCodec(), app.SimulationManager(), NewDefaultGenesisState(app.AppCodec())),
 		simtypes.RandomAccounts,
 		sims.SimulationOperations(app, app.AppCodec(), config),
 		app.ModuleAccountAddrs(),
@@ -226,7 +226,7 @@ func TestFullAppSimulation(t *testing.T) {
 		t,
 		os.Stdout,
 		app.BaseApp,
-		sims.AppStateFn(app.appCodec, app.SimulationManager(), app.DefaultGenesis()),
+		sims.AppStateFn(app.appCodec, app.SimulationManager(), NewDefaultGenesisState(app.AppCodec())),
 		simtypes.RandomAccounts, // Replace with own random account function if using keys other than secp256k1
 		sims.SimulationOperations(app, app.AppCodec(), config),
 		app.ModuleAccountAddrs(),

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -58,7 +58,7 @@ func setup(withGenesis bool, invCheckPeriod uint, opts ...wasm.Option) (*Archway
 	db := dbm.NewMemDB()
 	app := NewArchwayApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, DefaultNodeHome, invCheckPeriod, MakeEncodingConfig(), wasm.EnableAllProposals, EmptyBaseAppOptions{}, opts)
 	if withGenesis {
-		return app, NewDefaultGenesisState()
+		return app, NewDefaultGenesisState(app.AppCodec())
 	}
 	return app, GenesisState{}
 }

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -37,8 +37,8 @@ import (
 
 // DefaultConsensusParams defines the default Tendermint consensus params used in
 // ArchwayApp testing.
-var DefaultConsensusParams = &abci.ConsensusParams{
-	Block: &abci.BlockParams{
+var DefaultConsensusParams = &tmproto.ConsensusParams{
+	Block: &tmproto.BlockParams{
 		MaxBytes: 8000000,
 		MaxGas:   1234000000,
 	},
@@ -140,7 +140,7 @@ func SetupWithGenesisValSet(t *testing.T, valSet *tmtypes.ValidatorSet, genAccs 
 	})
 
 	// update total supply
-	bankGenesis := banktypes.NewGenesisState(banktypes.DefaultGenesisState().Params, balances, totalSupply, []banktypes.Metadata{})
+	bankGenesis := banktypes.NewGenesisState(banktypes.DefaultGenesisState().Params, balances, totalSupply, []banktypes.Metadata{}, []banktypes.SendEnabled{})
 	genesisState[banktypes.ModuleName] = app.appCodec.MustMarshalJSON(bankGenesis)
 
 	stateBytes, err := json.MarshalIndent(genesisState, "", " ")
@@ -179,7 +179,7 @@ func SetupWithGenesisAccounts(genAccs []authtypes.GenesisAccount, balances ...ba
 		totalSupply = totalSupply.Add(b.Coins...)
 	}
 
-	bankGenesis := banktypes.NewGenesisState(banktypes.DefaultGenesisState().Params, balances, totalSupply, []banktypes.Metadata{})
+	bankGenesis := banktypes.NewGenesisState(banktypes.DefaultGenesisState().Params, balances, totalSupply, []banktypes.Metadata{}, []banktypes.SendEnabled{})
 	genesisState[banktypes.ModuleName] = app.appCodec.MustMarshalJSON(bankGenesis)
 
 	stateBytes, err := json.MarshalIndent(genesisState, "", " ")
@@ -225,7 +225,7 @@ func createIncrementalAccounts(accNum int) []sdk.AccAddress {
 		buffer.WriteString("A58856F0FD53BF058B4909A21AEC019107BA6") // base address string
 
 		buffer.WriteString(numString) // adding on final two digits to make addresses unique
-		res, err := sdk.AccAddressFromHex(buffer.String())
+		res, err := sdk.AccAddressFromHexUnsafe(buffer.String())
 		if err != nil {
 			panic(err)
 		}
@@ -300,7 +300,7 @@ func ConvertAddrsToValAddrs(addrs []sdk.AccAddress) []sdk.ValAddress {
 }
 
 func TestAddr(addr, bech string) (sdk.AccAddress, error) {
-	res, err := sdk.AccAddressFromHex(addr)
+	res, err := sdk.AccAddressFromHexUnsafe(addr)
 	if err != nil {
 		return nil, err
 	}
@@ -363,7 +363,7 @@ func SignCheckDeliver(
 
 	// Simulate a sending a transaction and committing a block
 	app.BeginBlock(abci.RequestBeginBlock{Header: header})
-	gInfo, res, err := app.Deliver(txCfg.TxEncoder(), tx)
+	gInfo, res, err := app.SimDeliver(txCfg.TxEncoder(), tx)
 
 	if expPass {
 		require.NoError(t, err)
@@ -399,7 +399,7 @@ func SignAndDeliver(
 
 	// Simulate a sending a transaction and committing a block
 	app.BeginBlock(abci.RequestBeginBlock{Header: header})
-	gInfo, res, err := app.Deliver(txCfg.TxEncoder(), tx)
+	gInfo, res, err := app.SimDeliver(txCfg.TxEncoder(), tx)
 
 	if expPass {
 		require.NoError(t, err)

--- a/app/upgrades/2_0_0/upgrades.go
+++ b/app/upgrades/2_0_0/upgrades.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
@@ -28,7 +28,10 @@ var Upgrade = upgrades.Upgrade{
 		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 
 			// Set Initial Consensus Version
-			fromVM[icatypes.ModuleName] = mm.Modules[icatypes.ModuleName].ConsensusVersion()
+			icaModule := mm.Modules[icatypes.ModuleName]
+			if module, ok := icaModule.(module.HasConsensusVersion); ok {
+				fromVM[icatypes.ModuleName] = module.ConsensusVersion()
+			}
 			// create ICS27 Controller submodule params
 			controllerParams := icacontrollertypes.Params{}
 			// create ICS27 Host submodule params

--- a/app/upgrades/4_0_2/upgrades_test.go
+++ b/app/upgrades/4_0_2/upgrades_test.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"testing"
 
+	abci "github.com/cometbft/cometbft/abci/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	"github.com/stretchr/testify/suite"
-	abci "github.com/tendermint/tendermint/abci/types"
 
 	e2eTesting "github.com/archway-network/archway/e2e/testing"
 )

--- a/cmd/archwayd/genaccounts.go
+++ b/cmd/archwayd/genaccounts.go
@@ -1,192 +1,192 @@
 package main
 
-import (
-	"bufio"
-	"encoding/json"
-	"errors"
-	"fmt"
+// import (
+// 	"bufio"
+// 	"encoding/json"
+// 	"errors"
+// 	"fmt"
 
-	"github.com/spf13/cobra"
+// 	"github.com/spf13/cobra"
 
-	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-	"github.com/cosmos/cosmos-sdk/server"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	authvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	"github.com/cosmos/cosmos-sdk/x/genutil"
-	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
-)
+// 	"github.com/cosmos/cosmos-sdk/client"
+// 	"github.com/cosmos/cosmos-sdk/client/flags"
+// 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+// 	"github.com/cosmos/cosmos-sdk/server"
+// 	sdk "github.com/cosmos/cosmos-sdk/types"
+// 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+// 	authvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+// 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+// 	"github.com/cosmos/cosmos-sdk/x/genutil"
+// 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+// )
 
-const (
-	flagVestingStart = "vesting-start-time"
-	flagVestingEnd   = "vesting-end-time"
-	flagVestingAmt   = "vesting-amount"
-)
+// const (
+// 	flagVestingStart = "vesting-start-time"
+// 	flagVestingEnd   = "vesting-end-time"
+// 	flagVestingAmt   = "vesting-amount"
+// )
 
-// AddGenesisAccountCmd returns add-genesis-account cobra Command.
-func AddGenesisAccountCmd(defaultNodeHome string) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "add-genesis-account [address_or_key_name] [coin][,[coin]]",
-		Short: "Add a genesis account to genesis.json",
-		Long: `Add a genesis account to genesis.json. The provided account must specify
-the account address or key name and a list of initial coins. If a key name is given,
-the address will be looked up in the local Keybase. The list of initial tokens must
-contain valid denominations. Accounts may optionally be supplied with vesting parameters.
-`,
-		Args: cobra.ExactArgs(2),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx := client.GetClientContextFromCmd(cmd)
-			serverCtx := server.GetServerContextFromCmd(cmd)
-			config := serverCtx.Config
+// // AddGenesisAccountCmd returns add-genesis-account cobra Command.
+// func AddGenesisAccountCmd(defaultNodeHome string) *cobra.Command {
+// 	cmd := &cobra.Command{
+// 		Use:   "add-genesis-account [address_or_key_name] [coin][,[coin]]",
+// 		Short: "Add a genesis account to genesis.json",
+// 		Long: `Add a genesis account to genesis.json. The provided account must specify
+// the account address or key name and a list of initial coins. If a key name is given,
+// the address will be looked up in the local Keybase. The list of initial tokens must
+// contain valid denominations. Accounts may optionally be supplied with vesting parameters.
+// `,
+// 		Args: cobra.ExactArgs(2),
+// 		RunE: func(cmd *cobra.Command, args []string) error {
+// 			clientCtx := client.GetClientContextFromCmd(cmd)
+// 			serverCtx := server.GetServerContextFromCmd(cmd)
+// 			config := serverCtx.Config
 
-			config.SetRoot(clientCtx.HomeDir)
+// 			config.SetRoot(clientCtx.HomeDir)
 
-			var kr keyring.Keyring
-			addr, err := sdk.AccAddressFromBech32(args[0])
-			if err != nil {
-				inBuf := bufio.NewReader(cmd.InOrStdin())
-				keyringBackend, err := cmd.Flags().GetString(flags.FlagKeyringBackend)
-				if err != nil {
-					return fmt.Errorf("failed to parse keyring backend: %w", err)
-				}
-				if keyringBackend != "" && clientCtx.Keyring == nil {
-					var err error
-					kr, err = keyring.New(sdk.KeyringServiceName(), keyringBackend, clientCtx.HomeDir, inBuf)
-					if err != nil {
-						return err
-					}
-				} else {
-					kr = clientCtx.Keyring
-				}
+// 			var kr keyring.Keyring
+// 			addr, err := sdk.AccAddressFromBech32(args[0])
+// 			if err != nil {
+// 				inBuf := bufio.NewReader(cmd.InOrStdin())
+// 				keyringBackend, err := cmd.Flags().GetString(flags.FlagKeyringBackend)
+// 				if err != nil {
+// 					return fmt.Errorf("failed to parse keyring backend: %w", err)
+// 				}
+// 				if keyringBackend != "" && clientCtx.Keyring == nil {
+// 					var err error
+// 					kr, err = keyring.New(sdk.KeyringServiceName(), keyringBackend, clientCtx.HomeDir, inBuf)
+// 					if err != nil {
+// 						return err
+// 					}
+// 				} else {
+// 					kr = clientCtx.Keyring
+// 				}
 
-				info, err := kr.Key(args[0])
-				if err != nil {
-					return fmt.Errorf("failed to get address from Keyring: %w", err)
-				}
-				addr = info.GetAddress()
-			}
+// 				info, err := kr.Key(args[0])
+// 				if err != nil {
+// 					return fmt.Errorf("failed to get address from Keyring: %w", err)
+// 				}
+// 				addr = info.GetAddress()
+// 			}
 
-			coins, err := sdk.ParseCoinsNormalized(args[1])
-			if err != nil {
-				return fmt.Errorf("failed to parse coins: %w", err)
-			}
+// 			coins, err := sdk.ParseCoinsNormalized(args[1])
+// 			if err != nil {
+// 				return fmt.Errorf("failed to parse coins: %w", err)
+// 			}
 
-			vestingStart, err := cmd.Flags().GetInt64(flagVestingStart)
-			if err != nil {
-				return fmt.Errorf("failed to parse vesting start: %w", err)
-			}
-			vestingEnd, err := cmd.Flags().GetInt64(flagVestingEnd)
-			if err != nil {
-				return fmt.Errorf("failed to parse vesting end: %w", err)
-			}
-			vestingAmtStr, err := cmd.Flags().GetString(flagVestingAmt)
-			if err != nil {
-				return fmt.Errorf("failed to parse vesting amount: %w", err)
-			}
+// 			vestingStart, err := cmd.Flags().GetInt64(flagVestingStart)
+// 			if err != nil {
+// 				return fmt.Errorf("failed to parse vesting start: %w", err)
+// 			}
+// 			vestingEnd, err := cmd.Flags().GetInt64(flagVestingEnd)
+// 			if err != nil {
+// 				return fmt.Errorf("failed to parse vesting end: %w", err)
+// 			}
+// 			vestingAmtStr, err := cmd.Flags().GetString(flagVestingAmt)
+// 			if err != nil {
+// 				return fmt.Errorf("failed to parse vesting amount: %w", err)
+// 			}
 
-			vestingAmt, err := sdk.ParseCoinsNormalized(vestingAmtStr)
-			if err != nil {
-				return fmt.Errorf("failed to parse vesting amount: %w", err)
-			}
+// 			vestingAmt, err := sdk.ParseCoinsNormalized(vestingAmtStr)
+// 			if err != nil {
+// 				return fmt.Errorf("failed to parse vesting amount: %w", err)
+// 			}
 
-			// create concrete account type based on input parameters
-			var genAccount authtypes.GenesisAccount
+// 			// create concrete account type based on input parameters
+// 			var genAccount authtypes.GenesisAccount
 
-			balances := banktypes.Balance{Address: addr.String(), Coins: coins.Sort()}
-			baseAccount := authtypes.NewBaseAccount(addr, nil, 0, 0)
+// 			balances := banktypes.Balance{Address: addr.String(), Coins: coins.Sort()}
+// 			baseAccount := authtypes.NewBaseAccount(addr, nil, 0, 0)
 
-			if !vestingAmt.IsZero() {
-				baseVestingAccount := authvesting.NewBaseVestingAccount(baseAccount, vestingAmt.Sort(), vestingEnd)
+// 			if !vestingAmt.IsZero() {
+// 				baseVestingAccount := authvesting.NewBaseVestingAccount(baseAccount, vestingAmt.Sort(), vestingEnd)
 
-				if (balances.Coins.IsZero() && !baseVestingAccount.OriginalVesting.IsZero()) ||
-					baseVestingAccount.OriginalVesting.IsAnyGT(balances.Coins) {
-					return errors.New("vesting amount cannot be greater than total amount")
-				}
+// 				if (balances.Coins.IsZero() && !baseVestingAccount.OriginalVesting.IsZero()) ||
+// 					baseVestingAccount.OriginalVesting.IsAnyGT(balances.Coins) {
+// 					return errors.New("vesting amount cannot be greater than total amount")
+// 				}
 
-				switch {
-				case vestingStart != 0 && vestingEnd != 0:
-					genAccount = authvesting.NewContinuousVestingAccountRaw(baseVestingAccount, vestingStart)
+// 				switch {
+// 				case vestingStart != 0 && vestingEnd != 0:
+// 					genAccount = authvesting.NewContinuousVestingAccountRaw(baseVestingAccount, vestingStart)
 
-				case vestingEnd != 0:
-					genAccount = authvesting.NewDelayedVestingAccountRaw(baseVestingAccount)
+// 				case vestingEnd != 0:
+// 					genAccount = authvesting.NewDelayedVestingAccountRaw(baseVestingAccount)
 
-				default:
-					return errors.New("invalid vesting parameters; must supply start and end time or end time")
-				}
-			} else {
-				genAccount = baseAccount
-			}
+// 				default:
+// 					return errors.New("invalid vesting parameters; must supply start and end time or end time")
+// 				}
+// 			} else {
+// 				genAccount = baseAccount
+// 			}
 
-			if err := genAccount.Validate(); err != nil {
-				return fmt.Errorf("failed to validate new genesis account: %w", err)
-			}
+// 			if err := genAccount.Validate(); err != nil {
+// 				return fmt.Errorf("failed to validate new genesis account: %w", err)
+// 			}
 
-			genFile := config.GenesisFile()
-			appState, genDoc, err := genutiltypes.GenesisStateFromGenFile(genFile)
-			if err != nil {
-				return fmt.Errorf("failed to unmarshal genesis state: %w", err)
-			}
+// 			genFile := config.GenesisFile()
+// 			appState, genDoc, err := genutiltypes.GenesisStateFromGenFile(genFile)
+// 			if err != nil {
+// 				return fmt.Errorf("failed to unmarshal genesis state: %w", err)
+// 			}
 
-			authGenState := authtypes.GetGenesisStateFromAppState(clientCtx.Codec, appState)
+// 			authGenState := authtypes.GetGenesisStateFromAppState(clientCtx.Codec, appState)
 
-			accs, err := authtypes.UnpackAccounts(authGenState.Accounts)
-			if err != nil {
-				return fmt.Errorf("failed to get accounts from any: %w", err)
-			}
+// 			accs, err := authtypes.UnpackAccounts(authGenState.Accounts)
+// 			if err != nil {
+// 				return fmt.Errorf("failed to get accounts from any: %w", err)
+// 			}
 
-			if accs.Contains(addr) {
-				return fmt.Errorf("cannot add account at existing address %s", addr)
-			}
+// 			if accs.Contains(addr) {
+// 				return fmt.Errorf("cannot add account at existing address %s", addr)
+// 			}
 
-			// Add the new account to the set of genesis accounts and sanitize the
-			// accounts afterwards.
-			accs = append(accs, genAccount)
-			accs = authtypes.SanitizeGenesisAccounts(accs)
+// 			// Add the new account to the set of genesis accounts and sanitize the
+// 			// accounts afterwards.
+// 			accs = append(accs, genAccount)
+// 			accs = authtypes.SanitizeGenesisAccounts(accs)
 
-			genAccs, err := authtypes.PackAccounts(accs)
-			if err != nil {
-				return fmt.Errorf("failed to convert accounts into any's: %w", err)
-			}
-			authGenState.Accounts = genAccs
+// 			genAccs, err := authtypes.PackAccounts(accs)
+// 			if err != nil {
+// 				return fmt.Errorf("failed to convert accounts into any's: %w", err)
+// 			}
+// 			authGenState.Accounts = genAccs
 
-			authGenStateBz, err := clientCtx.Codec.MarshalJSON(&authGenState)
-			if err != nil {
-				return fmt.Errorf("failed to marshal auth genesis state: %w", err)
-			}
+// 			authGenStateBz, err := clientCtx.Codec.MarshalJSON(&authGenState)
+// 			if err != nil {
+// 				return fmt.Errorf("failed to marshal auth genesis state: %w", err)
+// 			}
 
-			appState[authtypes.ModuleName] = authGenStateBz
+// 			appState[authtypes.ModuleName] = authGenStateBz
 
-			bankGenState := banktypes.GetGenesisStateFromAppState(clientCtx.Codec, appState)
-			bankGenState.Balances = append(bankGenState.Balances, balances)
-			bankGenState.Balances = banktypes.SanitizeGenesisBalances(bankGenState.Balances)
-			bankGenState.Supply = bankGenState.Supply.Add(balances.Coins...)
+// 			bankGenState := banktypes.GetGenesisStateFromAppState(clientCtx.Codec, appState)
+// 			bankGenState.Balances = append(bankGenState.Balances, balances)
+// 			bankGenState.Balances = banktypes.SanitizeGenesisBalances(bankGenState.Balances)
+// 			bankGenState.Supply = bankGenState.Supply.Add(balances.Coins...)
 
-			bankGenStateBz, err := clientCtx.Codec.MarshalJSON(bankGenState)
-			if err != nil {
-				return fmt.Errorf("failed to marshal bank genesis state: %w", err)
-			}
+// 			bankGenStateBz, err := clientCtx.Codec.MarshalJSON(bankGenState)
+// 			if err != nil {
+// 				return fmt.Errorf("failed to marshal bank genesis state: %w", err)
+// 			}
 
-			appState[banktypes.ModuleName] = bankGenStateBz
+// 			appState[banktypes.ModuleName] = bankGenStateBz
 
-			appStateJSON, err := json.Marshal(appState)
-			if err != nil {
-				return fmt.Errorf("failed to marshal application genesis state: %w", err)
-			}
+// 			appStateJSON, err := json.Marshal(appState)
+// 			if err != nil {
+// 				return fmt.Errorf("failed to marshal application genesis state: %w", err)
+// 			}
 
-			genDoc.AppState = appStateJSON
-			return genutil.ExportGenesisFile(genDoc, genFile)
-		},
-	}
+// 			genDoc.AppState = appStateJSON
+// 			return genutil.ExportGenesisFile(genDoc, genFile)
+// 		},
+// 	}
 
-	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
-	cmd.Flags().String(flags.FlagKeyringBackend, flags.DefaultKeyringBackend, "Select keyring's backend (os|file|kwallet|pass|test)")
-	cmd.Flags().String(flagVestingAmt, "", "amount of coins for vesting accounts")
-	cmd.Flags().Int64(flagVestingStart, 0, "schedule start time (unix epoch) for vesting accounts")
-	cmd.Flags().Int64(flagVestingEnd, 0, "schedule end time (unix epoch) for vesting accounts")
-	flags.AddQueryFlagsToCmd(cmd)
+// 	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
+// 	cmd.Flags().String(flags.FlagKeyringBackend, flags.DefaultKeyringBackend, "Select keyring's backend (os|file|kwallet|pass|test)")
+// 	cmd.Flags().String(flagVestingAmt, "", "amount of coins for vesting accounts")
+// 	cmd.Flags().Int64(flagVestingStart, 0, "schedule start time (unix epoch) for vesting accounts")
+// 	cmd.Flags().Int64(flagVestingEnd, 0, "schedule end time (unix epoch) for vesting accounts")
+// 	flags.AddQueryFlagsToCmd(cmd)
 
-	return cmd
-}
+// 	return cmd
+// }

--- a/cmd/archwayd/main.go
+++ b/cmd/archwayd/main.go
@@ -19,7 +19,7 @@ func main() {
 
 	rootCmd.AddCommand(ensureLibWasmVM())
 
-	if err := svrcmd.Execute(rootCmd, app.DefaultNodeHome); err != nil {
+	if err := svrcmd.Execute(rootCmd, "ARCHWAY", app.DefaultNodeHome); err != nil {
 		switch e := err.(type) {
 		case server.ErrorCode:
 			logExit(e.Code, e.Error())

--- a/cmd/archwayd/root.go
+++ b/cmd/archwayd/root.go
@@ -58,7 +58,6 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 		WithLegacyAmino(encodingConfig.Amino).
 		WithInput(os.Stdin).
 		WithAccountRetriever(authtypes.AccountRetriever{}).
-		WithBroadcastMode(flags.BroadcastBlock).
 		WithHomeDir(app.DefaultNodeHome).
 		WithViper("")
 

--- a/cmd/archwayd/root.go
+++ b/cmd/archwayd/root.go
@@ -288,8 +288,8 @@ func (ac appCreator) appExport(
 	height int64,
 	forZeroHeight bool,
 	jailAllowedAddrs []string,
-	modulesToExport []string,
 	appOpts servertypes.AppOptions,
+	modulesToExport []string,
 ) (servertypes.ExportedApp, error) {
 	var archwayApp *app.ArchwayApp
 	homePath, ok := appOpts.Get(flags.FlagHome).(string)


### PR DESCRIPTION
- Updating the storekeys reference
- Updating the ante handlers 
    - `ante.NewRejectExtensionOptionsDecorator()` => `ante.NewExtensionOptionsDecorator(options.ExtensionOptionChecker)`
    - `ante.NewMempoolFeeDecorator()` => `ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker)`
    - `ibcante.NewAnteDecorator(options.IBCKeeper)` => `ibcante.NewRedundantRelayDecorator(options.IBCKeeper)`
- Updating the app export to allow export by module
- Updating the simulation package references
- Removing `add-genesis-account` and explicit references to gentx cmds as this is now provided by gentx commands superset 
- Adding `consensusParamsKeeper`