### PR TITLE
feat: modifying the upgrade handlers to pass in all the app keepers instead of just the account keeper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Contains all the PRs that improved the code without changing the behaviours.
 
 ### Changed
 
+- [#457](https://github.com/archway-network/archway/pull/457) - Modify the upgrade handlers to pass in all the app keepers instead of just the account keeper
+
 ### Deprecated
 
 - [#439](https://github.com/archway-network/archway/pull/439) - Renaming `debug` image to `dev`

--- a/app/app.go
+++ b/app/app.go
@@ -264,28 +264,8 @@ type ArchwayApp struct {
 	tkeys   map[string]*sdk.TransientStoreKey
 	memKeys map[string]*sdk.MemoryStoreKey
 
-	// keepers
-	AccountKeeper    authkeeper.AccountKeeper
-	BankKeeper       bankkeeper.Keeper
-	CapabilityKeeper *capabilitykeeper.Keeper
-	StakingKeeper    stakingkeeper.Keeper
-	slashingKeeper   slashingkeeper.Keeper
-	MintKeeper       mintkeeper.Keeper
-	DistrKeeper      distrkeeper.Keeper
-	GovKeeper        govkeeper.Keeper
-	CrisisKeeper     crisiskeeper.Keeper
-	UpgradeKeeper    upgradekeeper.Keeper
-	ParamsKeeper     paramskeeper.Keeper
-	IBCKeeper        *ibckeeper.Keeper // IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly
-	IBCFeeKeeper     ibcfeekeeper.Keeper
-	ICAHostKeeper    icahostkeeper.Keeper
-	EvidenceKeeper   evidencekeeper.Keeper
-	TransferKeeper   ibctransferkeeper.Keeper
-	FeeGrantKeeper   feegrantkeeper.Keeper
-	AuthzKeeper      authzkeeper.Keeper
-	WASMKeeper       wasm.Keeper
-	TrackingKeeper   trackingKeeper.Keeper
-	RewardsKeeper    rewardsKeeper.Keeper
+	// Keepers
+	Keepers ArchwayKeepers
 
 	ScopedIBCKeeper      capabilitykeeper.ScopedKeeper
 	ScopedICAHostKeeper  capabilitykeeper.ScopedKeeper
@@ -346,9 +326,10 @@ func NewArchwayApp(
 		keys:              keys,
 		tkeys:             tkeys,
 		memKeys:           memKeys,
+		Keepers:           ArchwayKeepers{},
 	}
 
-	app.ParamsKeeper = initParamsKeeper(
+	app.Keepers.ParamsKeeper = initParamsKeeper(
 		appCodec,
 		legacyAmino,
 		keys[paramstypes.StoreKey],
@@ -356,75 +337,75 @@ func NewArchwayApp(
 	)
 
 	// set the BaseApp's parameter store
-	bApp.SetParamStore(app.ParamsKeeper.Subspace(baseapp.Paramspace).WithKeyTable(paramskeeper.ConsensusParamsKeyTable()))
+	bApp.SetParamStore(app.Keepers.ParamsKeeper.Subspace(baseapp.Paramspace).WithKeyTable(paramskeeper.ConsensusParamsKeyTable()))
 
 	// add capability keeper and ScopeToModule for ibc module
-	app.CapabilityKeeper = capabilitykeeper.NewKeeper(
+	app.Keepers.CapabilityKeeper = capabilitykeeper.NewKeeper(
 		appCodec,
 		keys[capabilitytypes.StoreKey],
 		memKeys[capabilitytypes.MemStoreKey],
 	)
-	scopedIBCKeeper := app.CapabilityKeeper.ScopeToModule(ibchost.ModuleName)
-	scopedICAHostKeeper := app.CapabilityKeeper.ScopeToModule(icahosttypes.SubModuleName)
-	scopedTransferKeeper := app.CapabilityKeeper.ScopeToModule(ibctransfertypes.ModuleName)
-	scopedWasmKeeper := app.CapabilityKeeper.ScopeToModule(wasm.ModuleName)
-	app.CapabilityKeeper.Seal()
+	scopedIBCKeeper := app.Keepers.CapabilityKeeper.ScopeToModule(ibchost.ModuleName)
+	scopedICAHostKeeper := app.Keepers.CapabilityKeeper.ScopeToModule(icahosttypes.SubModuleName)
+	scopedTransferKeeper := app.Keepers.CapabilityKeeper.ScopeToModule(ibctransfertypes.ModuleName)
+	scopedWasmKeeper := app.Keepers.CapabilityKeeper.ScopeToModule(wasm.ModuleName)
+	app.Keepers.CapabilityKeeper.Seal()
 
 	// add keepers
-	app.AccountKeeper = authkeeper.NewAccountKeeper(
+	app.Keepers.AccountKeeper = authkeeper.NewAccountKeeper(
 		appCodec,
 		keys[authtypes.StoreKey],
 		app.getSubspace(authtypes.ModuleName),
 		authtypes.ProtoBaseAccount,
 		maccPerms,
 	)
-	app.BankKeeper = bankkeeper.NewBaseKeeper(
+	app.Keepers.BankKeeper = bankkeeper.NewBaseKeeper(
 		appCodec,
 		keys[banktypes.StoreKey],
-		app.AccountKeeper,
+		app.Keepers.AccountKeeper,
 		app.getSubspace(banktypes.ModuleName),
 		app.ModuleAccountAddrs(),
 	)
-	app.AuthzKeeper = authzkeeper.NewKeeper(
+	app.Keepers.AuthzKeeper = authzkeeper.NewKeeper(
 		keys[authzkeeper.StoreKey],
 		appCodec,
 		app.BaseApp.MsgServiceRouter(),
 	)
-	app.FeeGrantKeeper = feegrantkeeper.NewKeeper(
+	app.Keepers.FeeGrantKeeper = feegrantkeeper.NewKeeper(
 		appCodec,
 		keys[feegrant.StoreKey],
-		app.AccountKeeper,
+		app.Keepers.AccountKeeper,
 	)
 	stakingKeeper := stakingkeeper.NewKeeper(
 		appCodec,
 		keys[stakingtypes.StoreKey],
-		app.AccountKeeper,
-		app.BankKeeper,
+		app.Keepers.AccountKeeper,
+		app.Keepers.BankKeeper,
 		app.getSubspace(stakingtypes.ModuleName),
 	)
-	app.DistrKeeper = distrkeeper.NewKeeper(
+	app.Keepers.DistrKeeper = distrkeeper.NewKeeper(
 		appCodec,
 		keys[distrtypes.StoreKey],
 		app.getSubspace(distrtypes.ModuleName),
-		app.AccountKeeper,
-		app.BankKeeper,
+		app.Keepers.AccountKeeper,
+		app.Keepers.BankKeeper,
 		&stakingKeeper,
 		authtypes.FeeCollectorName,
 		app.ModuleAccountAddrs(),
 	)
-	app.slashingKeeper = slashingkeeper.NewKeeper(
+	app.Keepers.slashingKeeper = slashingkeeper.NewKeeper(
 		appCodec,
 		keys[slashingtypes.StoreKey],
 		&stakingKeeper,
 		app.getSubspace(slashingtypes.ModuleName),
 	)
-	app.CrisisKeeper = crisiskeeper.NewKeeper(
+	app.Keepers.CrisisKeeper = crisiskeeper.NewKeeper(
 		app.getSubspace(crisistypes.ModuleName),
 		invCheckPeriod,
-		app.BankKeeper,
+		app.Keepers.BankKeeper,
 		authtypes.FeeCollectorName,
 	)
-	app.UpgradeKeeper = upgradekeeper.NewKeeper(
+	app.Keepers.UpgradeKeeper = upgradekeeper.NewKeeper(
 		skipUpgradeHeights,
 		keys[upgradetypes.StoreKey],
 		appCodec,
@@ -434,16 +415,16 @@ func NewArchwayApp(
 
 	// register the staking hooks
 	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
-	app.StakingKeeper = *stakingKeeper.SetHooks(
-		stakingtypes.NewMultiStakingHooks(app.DistrKeeper.Hooks(), app.slashingKeeper.Hooks()),
+	app.Keepers.StakingKeeper = *stakingKeeper.SetHooks(
+		stakingtypes.NewMultiStakingHooks(app.Keepers.DistrKeeper.Hooks(), app.Keepers.slashingKeeper.Hooks()),
 	)
 
-	app.IBCKeeper = ibckeeper.NewKeeper(
+	app.Keepers.IBCKeeper = ibckeeper.NewKeeper(
 		appCodec,
 		keys[ibchost.StoreKey],
 		app.getSubspace(ibchost.ModuleName),
-		app.StakingKeeper,
-		app.UpgradeKeeper,
+		app.Keepers.StakingKeeper,
+		app.Keepers.UpgradeKeeper,
 		scopedIBCKeeper,
 	)
 
@@ -451,40 +432,40 @@ func NewArchwayApp(
 	govRouter := govtypes.NewRouter()
 	govRouter.
 		AddRoute(govtypes.RouterKey, govtypes.ProposalHandler).
-		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(app.ParamsKeeper)).
-		AddRoute(distrtypes.RouterKey, distr.NewCommunityPoolSpendProposalHandler(app.DistrKeeper)).
-		AddRoute(upgradetypes.RouterKey, upgrade.NewSoftwareUpgradeProposalHandler(app.UpgradeKeeper)).
-		AddRoute(ibcclienttypes.RouterKey, ibcclient.NewClientProposalHandler(app.IBCKeeper.ClientKeeper))
+		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(app.Keepers.ParamsKeeper)).
+		AddRoute(distrtypes.RouterKey, distr.NewCommunityPoolSpendProposalHandler(app.Keepers.DistrKeeper)).
+		AddRoute(upgradetypes.RouterKey, upgrade.NewSoftwareUpgradeProposalHandler(app.Keepers.UpgradeKeeper)).
+		AddRoute(ibcclienttypes.RouterKey, ibcclient.NewClientProposalHandler(app.Keepers.IBCKeeper.ClientKeeper))
 
 	// IBC Fee Module keeper
-	app.IBCFeeKeeper = ibcfeekeeper.NewKeeper(
+	app.Keepers.IBCFeeKeeper = ibcfeekeeper.NewKeeper(
 		appCodec, keys[ibcfeetypes.StoreKey], app.getSubspace(ibcfeetypes.ModuleName),
-		app.IBCKeeper.ChannelKeeper, // may be replaced with IBC middleware
-		app.IBCKeeper.ChannelKeeper,
-		&app.IBCKeeper.PortKeeper, app.AccountKeeper, app.BankKeeper,
+		app.Keepers.IBCKeeper.ChannelKeeper, // may be replaced with IBC middleware
+		app.Keepers.IBCKeeper.ChannelKeeper,
+		&app.Keepers.IBCKeeper.PortKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper,
 	)
 
 	// Create Transfer Keepers
-	app.TransferKeeper = ibctransferkeeper.NewKeeper(
+	app.Keepers.TransferKeeper = ibctransferkeeper.NewKeeper(
 		appCodec,
 		keys[ibctransfertypes.StoreKey],
 		app.getSubspace(ibctransfertypes.ModuleName),
-		app.IBCFeeKeeper, // ISC4 Wrapper: fee IBC middleware
-		app.IBCKeeper.ChannelKeeper,
-		&app.IBCKeeper.PortKeeper,
-		app.AccountKeeper,
-		app.BankKeeper,
+		app.Keepers.IBCFeeKeeper, // ISC4 Wrapper: fee IBC middleware
+		app.Keepers.IBCKeeper.ChannelKeeper,
+		&app.Keepers.IBCKeeper.PortKeeper,
+		app.Keepers.AccountKeeper,
+		app.Keepers.BankKeeper,
 		scopedTransferKeeper)
 
-	transferModule := transfer.NewAppModule(app.TransferKeeper)
+	transferModule := transfer.NewAppModule(app.Keepers.TransferKeeper)
 
-	app.ICAHostKeeper = icahostkeeper.NewKeeper(
+	app.Keepers.ICAHostKeeper = icahostkeeper.NewKeeper(
 		appCodec,
 		keys[icahosttypes.StoreKey],
 		app.getSubspace(icahosttypes.SubModuleName),
-		app.IBCKeeper.ChannelKeeper,
-		&app.IBCKeeper.PortKeeper,
-		app.AccountKeeper,
+		app.Keepers.IBCKeeper.ChannelKeeper,
+		&app.Keepers.IBCKeeper.PortKeeper,
+		app.Keepers.AccountKeeper,
 		scopedICAHostKeeper,
 		app.MsgServiceRouter(),
 	)
@@ -493,14 +474,14 @@ func NewArchwayApp(
 	evidenceKeeper := evidencekeeper.NewKeeper(
 		appCodec,
 		keys[evidencetypes.StoreKey],
-		&app.StakingKeeper,
-		app.slashingKeeper,
+		&app.Keepers.StakingKeeper,
+		app.Keepers.slashingKeeper,
 	)
-	app.EvidenceKeeper = *evidenceKeeper
+	app.Keepers.EvidenceKeeper = *evidenceKeeper
 
 	defaultGasRegister := wasmdKeeper.NewDefaultWasmGasRegister()
 
-	app.TrackingKeeper = trackingKeeper.NewKeeper(
+	app.Keepers.TrackingKeeper = trackingKeeper.NewKeeper(
 		appCodec,
 		keys[trackingTypes.StoreKey],
 		defaultGasRegister,
@@ -525,21 +506,21 @@ func NewArchwayApp(
 
 	wasmOpts = append(wasmOpts, wasmdKeeper.WithWasmEngine(trackingWasmVm), wasmdKeeper.WithGasRegister(defaultGasRegister))
 	// Archway specific options (using a pointer as the keeper is post-initialized below)
-	wasmOpts = append(wasmOpts, wasmbinding.BuildWasmOptions(&app.RewardsKeeper, &app.GovKeeper)...)
+	wasmOpts = append(wasmOpts, wasmbinding.BuildWasmOptions(&app.Keepers.RewardsKeeper, &app.Keepers.GovKeeper)...)
 
-	app.WASMKeeper = wasm.NewKeeper(
+	app.Keepers.WASMKeeper = wasm.NewKeeper(
 		appCodec,
 		keys[wasm.StoreKey],
 		app.getSubspace(wasm.ModuleName),
-		app.AccountKeeper,
-		app.BankKeeper,
-		app.StakingKeeper,
-		app.DistrKeeper,
-		app.IBCFeeKeeper, // ISC4 Wrapper: fee IBC middleware
-		app.IBCKeeper.ChannelKeeper,
-		&app.IBCKeeper.PortKeeper,
+		app.Keepers.AccountKeeper,
+		app.Keepers.BankKeeper,
+		app.Keepers.StakingKeeper,
+		app.Keepers.DistrKeeper,
+		app.Keepers.IBCFeeKeeper, // ISC4 Wrapper: fee IBC middleware
+		app.Keepers.IBCKeeper.ChannelKeeper,
+		&app.Keepers.IBCKeeper.PortKeeper,
 		scopedWasmKeeper,
-		app.TransferKeeper,
+		app.Keepers.TransferKeeper,
 		app.MsgServiceRouter(),
 		app.GRPCQueryRouter(),
 		wasmDir,
@@ -549,62 +530,62 @@ func NewArchwayApp(
 	)
 
 	// Setting gas recorder here to avoid cyclic loop
-	trackingWasmVm.SetGasRecorder(app.TrackingKeeper)
+	trackingWasmVm.SetGasRecorder(app.Keepers.TrackingKeeper)
 
-	app.RewardsKeeper = rewardsKeeper.NewKeeper(
+	app.Keepers.RewardsKeeper = rewardsKeeper.NewKeeper(
 		appCodec,
 		keys[rewardsTypes.StoreKey],
-		app.WASMKeeper,
-		app.TrackingKeeper,
-		app.AccountKeeper,
-		app.BankKeeper,
+		app.Keepers.WASMKeeper,
+		app.Keepers.TrackingKeeper,
+		app.Keepers.AccountKeeper,
+		app.Keepers.BankKeeper,
 		app.getSubspace(rewardsTypes.ModuleName),
 	)
 
 	// Note we set up mint keeper after the x/rewards keeper
-	app.MintKeeper = mintkeeper.NewKeeper(
+	app.Keepers.MintKeeper = mintkeeper.NewKeeper(
 		appCodec,
 		keys[minttypes.StoreKey],
 		app.getSubspace(minttypes.ModuleName),
 		&stakingKeeper,
-		app.AccountKeeper,
-		mintbankkeeper.NewKeeper(app.BankKeeper, app.RewardsKeeper),
+		app.Keepers.AccountKeeper,
+		mintbankkeeper.NewKeeper(app.Keepers.BankKeeper, app.Keepers.RewardsKeeper),
 		authtypes.FeeCollectorName,
 	)
 
 	// The gov proposal types can be individually enabled
 	if len(enabledProposals) != 0 {
-		govRouter.AddRoute(wasm.RouterKey, wasm.NewWasmProposalHandler(app.WASMKeeper, enabledProposals))
+		govRouter.AddRoute(wasm.RouterKey, wasm.NewWasmProposalHandler(app.Keepers.WASMKeeper, enabledProposals))
 	}
 
 	var transferStack porttypes.IBCModule
-	transferStack = transfer.NewIBCModule(app.TransferKeeper)
-	transferStack = ibcfee.NewIBCMiddleware(transferStack, app.IBCFeeKeeper)
+	transferStack = transfer.NewIBCModule(app.Keepers.TransferKeeper)
+	transferStack = ibcfee.NewIBCMiddleware(transferStack, app.Keepers.IBCFeeKeeper)
 
 	// Create Interchain Accounts Stack
 	// RecvPacket, message that originates from core IBC and goes down to app, the flow is:
 	// channel.RecvPacket -> fee.OnRecvPacket -> icaHost.OnRecvPacket
 	var icaHostStack porttypes.IBCModule
-	icaHostStack = icahost.NewIBCModule(app.ICAHostKeeper)
-	icaHostStack = ibcfee.NewIBCMiddleware(icaHostStack, app.IBCFeeKeeper)
+	icaHostStack = icahost.NewIBCModule(app.Keepers.ICAHostKeeper)
+	icaHostStack = ibcfee.NewIBCMiddleware(icaHostStack, app.Keepers.IBCFeeKeeper)
 
 	var wasmStack porttypes.IBCModule
-	wasmStack = wasm.NewIBCHandler(app.WASMKeeper, app.IBCKeeper.ChannelKeeper, app.IBCFeeKeeper)
-	wasmStack = ibcfee.NewIBCMiddleware(wasmStack, app.IBCFeeKeeper)
+	wasmStack = wasm.NewIBCHandler(app.Keepers.WASMKeeper, app.Keepers.IBCKeeper.ChannelKeeper, app.Keepers.IBCFeeKeeper)
+	wasmStack = ibcfee.NewIBCMiddleware(wasmStack, app.Keepers.IBCFeeKeeper)
 
 	// create static IBC router, add transfer route, add wasm route, then set and seal it
 	ibcRouter := porttypes.NewRouter()
 	ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferStack)
 	ibcRouter.AddRoute(wasm.ModuleName, wasmStack)
 	ibcRouter.AddRoute(icahosttypes.SubModuleName, icaHostStack)
-	app.IBCKeeper.SetRouter(ibcRouter)
+	app.Keepers.IBCKeeper.SetRouter(ibcRouter)
 
-	app.GovKeeper = govkeeper.NewKeeper(
+	app.Keepers.GovKeeper = govkeeper.NewKeeper(
 		appCodec,
 		keys[govtypes.StoreKey],
 		app.getSubspace(govtypes.ModuleName),
-		app.AccountKeeper,
-		app.BankKeeper,
+		app.Keepers.AccountKeeper,
+		app.Keepers.BankKeeper,
 		&stakingKeeper,
 		govRouter,
 	)
@@ -618,34 +599,34 @@ func NewArchwayApp(
 	// must be passed by reference here.
 	app.mm = module.NewManager(
 		genutil.NewAppModule(
-			app.AccountKeeper,
-			app.StakingKeeper,
+			app.Keepers.AccountKeeper,
+			app.Keepers.StakingKeeper,
 			app.BaseApp.DeliverTx,
 			encodingConfig.TxConfig,
 		),
-		auth.NewAppModule(appCodec, app.AccountKeeper, nil),
-		vesting.NewAppModule(app.AccountKeeper, app.BankKeeper),
-		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper),
-		capability.NewAppModule(appCodec, *app.CapabilityKeeper),
-		gov.NewAppModule(appCodec, app.GovKeeper, app.AccountKeeper, app.BankKeeper),
-		mint.NewAppModule(appCodec, app.MintKeeper, app.AccountKeeper),
-		slashing.NewAppModule(appCodec, app.slashingKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
-		distr.NewAppModule(appCodec, app.DistrKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
-		staking.NewAppModule(appCodec, app.StakingKeeper, app.AccountKeeper, app.BankKeeper),
-		upgrade.NewAppModule(app.UpgradeKeeper),
-		wasm.NewAppModule(appCodec, &app.WASMKeeper, app.StakingKeeper, app.AccountKeeper, app.BankKeeper),
-		evidence.NewAppModule(app.EvidenceKeeper),
-		feegrantmodule.NewAppModule(appCodec, app.AccountKeeper, app.BankKeeper, app.FeeGrantKeeper, app.interfaceRegistry),
-		authzmodule.NewAppModule(appCodec, app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
-		ibc.NewAppModule(app.IBCKeeper),
-		params.NewAppModule(app.ParamsKeeper),
+		auth.NewAppModule(appCodec, app.Keepers.AccountKeeper, nil),
+		vesting.NewAppModule(app.Keepers.AccountKeeper, app.Keepers.BankKeeper),
+		bank.NewAppModule(appCodec, app.Keepers.BankKeeper, app.Keepers.AccountKeeper),
+		capability.NewAppModule(appCodec, *app.Keepers.CapabilityKeeper),
+		gov.NewAppModule(appCodec, app.Keepers.GovKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper),
+		mint.NewAppModule(appCodec, app.Keepers.MintKeeper, app.Keepers.AccountKeeper),
+		slashing.NewAppModule(appCodec, app.Keepers.slashingKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.Keepers.StakingKeeper),
+		distr.NewAppModule(appCodec, app.Keepers.DistrKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.Keepers.StakingKeeper),
+		staking.NewAppModule(appCodec, app.Keepers.StakingKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper),
+		upgrade.NewAppModule(app.Keepers.UpgradeKeeper),
+		wasm.NewAppModule(appCodec, &app.Keepers.WASMKeeper, app.Keepers.StakingKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper),
+		evidence.NewAppModule(app.Keepers.EvidenceKeeper),
+		feegrantmodule.NewAppModule(appCodec, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.Keepers.FeeGrantKeeper, app.interfaceRegistry),
+		authzmodule.NewAppModule(appCodec, app.Keepers.AuthzKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.interfaceRegistry),
+		ibc.NewAppModule(app.Keepers.IBCKeeper),
+		params.NewAppModule(app.Keepers.ParamsKeeper),
 		transferModule,
-		ibcfee.NewAppModule(app.IBCFeeKeeper),
-		ica.NewAppModule(nil, &app.ICAHostKeeper),
-		tracking.NewAppModule(app.appCodec, app.TrackingKeeper),
-		rewards.NewAppModule(app.appCodec, app.RewardsKeeper),
+		ibcfee.NewAppModule(app.Keepers.IBCFeeKeeper),
+		ica.NewAppModule(nil, &app.Keepers.ICAHostKeeper),
+		tracking.NewAppModule(app.appCodec, app.Keepers.TrackingKeeper),
+		rewards.NewAppModule(app.appCodec, app.Keepers.RewardsKeeper),
 		genmsg.NewAppModule(app.MsgServiceRouter()),
-		crisis.NewAppModule(&app.CrisisKeeper, skipGenesisInvariants), // always be last to make sure that it checks for all invariants and not only part of them
+		crisis.NewAppModule(&app.Keepers.CrisisKeeper, skipGenesisInvariants), // always be last to make sure that it checks for all invariants and not only part of them
 	)
 
 	// During begin block slashing happens after distr.BeginBlocker so that
@@ -754,7 +735,7 @@ func NewArchwayApp(
 	// Uncomment if you want to set a custom migration order here.
 	// app.mm.SetOrderMigrations(custom order)
 
-	app.mm.RegisterInvariants(&app.CrisisKeeper)
+	app.mm.RegisterInvariants(&app.Keepers.CrisisKeeper)
 	app.mm.RegisterRoutes(app.Router(), app.QueryRouter(), encodingConfig.Amino)
 
 	app.configurator = module.NewConfigurator(app.appCodec, app.MsgServiceRouter(), app.GRPCQueryRouter())
@@ -766,20 +747,20 @@ func NewArchwayApp(
 	// NOTE: this is not required apps that don't use the simulator for fuzz testing
 	// transactions
 	app.sm = module.NewSimulationManager(
-		auth.NewAppModule(appCodec, app.AccountKeeper, authsims.RandomGenesisAccounts),
-		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper),
-		capability.NewAppModule(appCodec, *app.CapabilityKeeper),
-		feegrantmodule.NewAppModule(appCodec, app.AccountKeeper, app.BankKeeper, app.FeeGrantKeeper, app.interfaceRegistry),
-		authzmodule.NewAppModule(appCodec, app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
-		gov.NewAppModule(appCodec, app.GovKeeper, app.AccountKeeper, app.BankKeeper),
-		mint.NewAppModule(appCodec, app.MintKeeper, app.AccountKeeper),
-		staking.NewAppModule(appCodec, app.StakingKeeper, app.AccountKeeper, app.BankKeeper),
-		distr.NewAppModule(appCodec, app.DistrKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
-		slashing.NewAppModule(appCodec, app.slashingKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
-		params.NewAppModule(app.ParamsKeeper),
-		evidence.NewAppModule(app.EvidenceKeeper),
-		wasm.NewAppModule(appCodec, &app.WASMKeeper, app.StakingKeeper, app.AccountKeeper, app.BankKeeper),
-		ibc.NewAppModule(app.IBCKeeper),
+		auth.NewAppModule(appCodec, app.Keepers.AccountKeeper, authsims.RandomGenesisAccounts),
+		bank.NewAppModule(appCodec, app.Keepers.BankKeeper, app.Keepers.AccountKeeper),
+		capability.NewAppModule(appCodec, *app.Keepers.CapabilityKeeper),
+		feegrantmodule.NewAppModule(appCodec, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.Keepers.FeeGrantKeeper, app.interfaceRegistry),
+		authzmodule.NewAppModule(appCodec, app.Keepers.AuthzKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.interfaceRegistry),
+		gov.NewAppModule(appCodec, app.Keepers.GovKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper),
+		mint.NewAppModule(appCodec, app.Keepers.MintKeeper, app.Keepers.AccountKeeper),
+		staking.NewAppModule(appCodec, app.Keepers.StakingKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper),
+		distr.NewAppModule(appCodec, app.Keepers.DistrKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.Keepers.StakingKeeper),
+		slashing.NewAppModule(appCodec, app.Keepers.slashingKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.Keepers.StakingKeeper),
+		params.NewAppModule(app.Keepers.ParamsKeeper),
+		evidence.NewAppModule(app.Keepers.EvidenceKeeper),
+		wasm.NewAppModule(appCodec, &app.Keepers.WASMKeeper, app.Keepers.StakingKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper),
+		ibc.NewAppModule(app.Keepers.IBCKeeper),
 		transferModule,
 	)
 
@@ -793,18 +774,18 @@ func NewArchwayApp(
 	anteHandler, err := NewAnteHandler(
 		HandlerOptions{
 			HandlerOptions: ante.HandlerOptions{
-				AccountKeeper:   app.AccountKeeper,
-				BankKeeper:      app.BankKeeper,
-				FeegrantKeeper:  app.FeeGrantKeeper,
+				AccountKeeper:   app.Keepers.AccountKeeper,
+				BankKeeper:      app.Keepers.BankKeeper,
+				FeegrantKeeper:  app.Keepers.FeeGrantKeeper,
 				SignModeHandler: encodingConfig.TxConfig.SignModeHandler(),
 				SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
 			},
-			IBCKeeper:             app.IBCKeeper,
+			IBCKeeper:             app.Keepers.IBCKeeper,
 			WasmConfig:            &wasmConfig,
-			RewardsAnteBankKeeper: app.BankKeeper,
+			RewardsAnteBankKeeper: app.Keepers.BankKeeper,
 			TXCounterStoreKey:     keys[wasm.StoreKey],
-			TrackingKeeper:        app.TrackingKeeper,
-			RewardsKeeper:         app.RewardsKeeper,
+			TrackingKeeper:        app.Keepers.TrackingKeeper,
+			RewardsKeeper:         app.Keepers.RewardsKeeper,
 		},
 	)
 	if err != nil {
@@ -819,7 +800,7 @@ func NewArchwayApp(
 	// Register snapshot extensions to enable state-sync for wasm - must be before Loading version
 	if manager := app.SnapshotManager(); manager != nil {
 		err := manager.RegisterExtensions(
-			wasmdKeeper.NewWasmSnapshotter(app.CommitMultiStore(), &app.WASMKeeper),
+			wasmdKeeper.NewWasmSnapshotter(app.CommitMultiStore(), &app.Keepers.WASMKeeper),
 		)
 		if err != nil {
 			panic(fmt.Errorf("failed to register snapshot extension: %s", err))
@@ -833,7 +814,7 @@ func NewArchwayApp(
 		ctx := app.BaseApp.NewUncachedContext(true, tmproto.Header{})
 
 		// Initialize pinned codes in wasmvm as they are not persisted there
-		if err := app.WASMKeeper.InitializePinnedCodes(ctx); err != nil {
+		if err := app.Keepers.WASMKeeper.InitializePinnedCodes(ctx); err != nil {
 			tmos.Exit(fmt.Sprintf("failed initialize pinned codes %s", err))
 		}
 	}
@@ -865,7 +846,7 @@ func (app *ArchwayApp) InitChainer(ctx sdk.Context, req abci.RequestInitChain) a
 		panic(err)
 	}
 
-	app.UpgradeKeeper.SetModuleVersionMap(ctx, app.mm.GetVersionMap())
+	app.Keepers.UpgradeKeeper.SetModuleVersionMap(ctx, app.mm.GetVersionMap())
 
 	return app.mm.InitGenesis(ctx, app.appCodec, genesisState)
 }
@@ -897,7 +878,7 @@ func (app *ArchwayApp) LegacyAmino() *codec.LegacyAmino { //nolint:staticcheck
 //
 // NOTE: This is solely to be used for testing purposes.
 func (app *ArchwayApp) getSubspace(moduleName string) paramstypes.Subspace {
-	subspace, _ := app.ParamsKeeper.GetSubspace(moduleName)
+	subspace, _ := app.Keepers.ParamsKeeper.GetSubspace(moduleName)
 	return subspace
 }
 

--- a/app/app.go
+++ b/app/app.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/archway-network/archway/app/keepers"
 	"github.com/archway-network/archway/x/genmsg"
 
 	wasmdKeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
@@ -265,7 +266,7 @@ type ArchwayApp struct {
 	memKeys map[string]*sdk.MemoryStoreKey
 
 	// Keepers
-	Keepers ArchwayKeepers
+	Keepers keepers.ArchwayKeepers
 
 	ScopedIBCKeeper      capabilitykeeper.ScopedKeeper
 	ScopedICAHostKeeper  capabilitykeeper.ScopedKeeper
@@ -326,7 +327,7 @@ func NewArchwayApp(
 		keys:              keys,
 		tkeys:             tkeys,
 		memKeys:           memKeys,
-		Keepers:           ArchwayKeepers{},
+		Keepers:           keepers.ArchwayKeepers{},
 	}
 
 	app.Keepers.ParamsKeeper = initParamsKeeper(
@@ -393,7 +394,7 @@ func NewArchwayApp(
 		authtypes.FeeCollectorName,
 		app.ModuleAccountAddrs(),
 	)
-	app.Keepers.slashingKeeper = slashingkeeper.NewKeeper(
+	app.Keepers.SlashingKeeper = slashingkeeper.NewKeeper(
 		appCodec,
 		keys[slashingtypes.StoreKey],
 		&stakingKeeper,
@@ -416,7 +417,7 @@ func NewArchwayApp(
 	// register the staking hooks
 	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
 	app.Keepers.StakingKeeper = *stakingKeeper.SetHooks(
-		stakingtypes.NewMultiStakingHooks(app.Keepers.DistrKeeper.Hooks(), app.Keepers.slashingKeeper.Hooks()),
+		stakingtypes.NewMultiStakingHooks(app.Keepers.DistrKeeper.Hooks(), app.Keepers.SlashingKeeper.Hooks()),
 	)
 
 	app.Keepers.IBCKeeper = ibckeeper.NewKeeper(
@@ -475,7 +476,7 @@ func NewArchwayApp(
 		appCodec,
 		keys[evidencetypes.StoreKey],
 		&app.Keepers.StakingKeeper,
-		app.Keepers.slashingKeeper,
+		app.Keepers.SlashingKeeper,
 	)
 	app.Keepers.EvidenceKeeper = *evidenceKeeper
 
@@ -610,7 +611,7 @@ func NewArchwayApp(
 		capability.NewAppModule(appCodec, *app.Keepers.CapabilityKeeper),
 		gov.NewAppModule(appCodec, app.Keepers.GovKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper),
 		mint.NewAppModule(appCodec, app.Keepers.MintKeeper, app.Keepers.AccountKeeper),
-		slashing.NewAppModule(appCodec, app.Keepers.slashingKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.Keepers.StakingKeeper),
+		slashing.NewAppModule(appCodec, app.Keepers.SlashingKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.Keepers.StakingKeeper),
 		distr.NewAppModule(appCodec, app.Keepers.DistrKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.Keepers.StakingKeeper),
 		staking.NewAppModule(appCodec, app.Keepers.StakingKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper),
 		upgrade.NewAppModule(app.Keepers.UpgradeKeeper),
@@ -756,7 +757,7 @@ func NewArchwayApp(
 		mint.NewAppModule(appCodec, app.Keepers.MintKeeper, app.Keepers.AccountKeeper),
 		staking.NewAppModule(appCodec, app.Keepers.StakingKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper),
 		distr.NewAppModule(appCodec, app.Keepers.DistrKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.Keepers.StakingKeeper),
-		slashing.NewAppModule(appCodec, app.Keepers.slashingKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.Keepers.StakingKeeper),
+		slashing.NewAppModule(appCodec, app.Keepers.SlashingKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper, app.Keepers.StakingKeeper),
 		params.NewAppModule(app.Keepers.ParamsKeeper),
 		evidence.NewAppModule(app.Keepers.EvidenceKeeper),
 		wasm.NewAppModule(appCodec, &app.Keepers.WASMKeeper, app.Keepers.StakingKeeper, app.Keepers.AccountKeeper, app.Keepers.BankKeeper),

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -47,7 +47,7 @@ func TestBlockedAddrs(t *testing.T) {
 
 	for acc := range maccPerms {
 		t.Run(acc, func(t *testing.T) {
-			require.True(t, gapp.BankKeeper.BlockedAddr(gapp.AccountKeeper.GetModuleAddress(acc)),
+			require.True(t, gapp.Keepers.BankKeeper.BlockedAddr(gapp.Keepers.AccountKeeper.GetModuleAddress(acc)),
 				"ensure that blocked addresses are properly set in bank keeper",
 			)
 		})

--- a/app/app_upgrades.go
+++ b/app/app_upgrades.go
@@ -54,7 +54,7 @@ func (app *ArchwayApp) setUpgradeHandlers() {
 	for _, u := range Upgrades {
 		app.Keepers.UpgradeKeeper.SetUpgradeHandler(
 			u.UpgradeName,
-			u.CreateUpgradeHandler(app.mm, app.configurator, app.Keepers.AccountKeeper),
+			u.CreateUpgradeHandler(app.mm, app.configurator, app.Keepers),
 		)
 	}
 }

--- a/app/app_upgrades.go
+++ b/app/app_upgrades.go
@@ -34,12 +34,12 @@ func (app *ArchwayApp) setupUpgrades() {
 }
 
 func (app *ArchwayApp) setUpgradeStoreLoaders() {
-	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
+	upgradeInfo, err := app.Keepers.UpgradeKeeper.ReadUpgradeInfoFromDisk()
 	if err != nil {
 		panic(fmt.Sprintf("failed to read upgrade info from disk %s", err))
 	}
 
-	if app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+	if app.Keepers.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		return
 	}
 
@@ -52,9 +52,9 @@ func (app *ArchwayApp) setUpgradeStoreLoaders() {
 
 func (app *ArchwayApp) setUpgradeHandlers() {
 	for _, u := range Upgrades {
-		app.UpgradeKeeper.SetUpgradeHandler(
+		app.Keepers.UpgradeKeeper.SetUpgradeHandler(
 			u.UpgradeName,
-			u.CreateUpgradeHandler(app.mm, app.configurator, app.AccountKeeper),
+			u.CreateUpgradeHandler(app.mm, app.configurator, app.Keepers.AccountKeeper),
 		)
 	}
 }

--- a/app/app_upgrades_test.go
+++ b/app/app_upgrades_test.go
@@ -7,10 +7,10 @@ import (
 	storeTypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	"github.com/stretchr/testify/require"
 
+	"github.com/archway-network/archway/app/keepers"
 	"github.com/archway-network/archway/app/upgrades"
 	e2eTesting "github.com/archway-network/archway/e2e/testing"
 	rewardsTypes "github.com/archway-network/archway/x/rewards/types"
@@ -45,7 +45,7 @@ func TestUpgrades(t *testing.T) {
 	proposalExecuted := false
 	fauxUpgrade := upgrades.Upgrade{
 		UpgradeName: "test-upgrade",
-		CreateUpgradeHandler: func(manager *module.Manager, configurator module.Configurator, _ keeper.AccountKeeper) upgradetypes.UpgradeHandler {
+		CreateUpgradeHandler: func(manager *module.Manager, configurator module.Configurator, _ keepers.ArchwayKeepers) upgradetypes.UpgradeHandler {
 			return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 				proposalExecuted = true
 				return manager.RunMigrations(ctx, configurator, fromVM)

--- a/app/app_upgrades_util_test.go
+++ b/app/app_upgrades_util_test.go
@@ -7,6 +7,6 @@ import "github.com/archway-network/archway/app/upgrades"
 func (app *ArchwayApp) AddUpgradeHandler(upgrade upgrades.Upgrade) {
 	app.Keepers.UpgradeKeeper.SetUpgradeHandler(
 		upgrade.UpgradeName,
-		upgrade.CreateUpgradeHandler(app.mm, app.configurator, app.Keepers.AccountKeeper),
+		upgrade.CreateUpgradeHandler(app.mm, app.configurator, app.Keepers),
 	)
 }

--- a/app/app_upgrades_util_test.go
+++ b/app/app_upgrades_util_test.go
@@ -5,8 +5,8 @@ import "github.com/archway-network/archway/app/upgrades"
 // AddUpgradeHandler is used only for testing, and compiles as a function only in testing.
 // We cannot add it to app_upgrades_test.go to avoid import cycles.
 func (app *ArchwayApp) AddUpgradeHandler(upgrade upgrades.Upgrade) {
-	app.UpgradeKeeper.SetUpgradeHandler(
+	app.Keepers.UpgradeKeeper.SetUpgradeHandler(
 		upgrade.UpgradeName,
-		upgrade.CreateUpgradeHandler(app.mm, app.configurator, app.AccountKeeper),
+		upgrade.CreateUpgradeHandler(app.mm, app.configurator, app.Keepers.AccountKeeper),
 	)
 }

--- a/app/export.go
+++ b/app/export.go
@@ -183,11 +183,11 @@ func (app *ArchwayApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddr
 	/* Handle slashing state. */
 
 	// reset start height on signing infos
-	app.Keepers.slashingKeeper.IterateValidatorSigningInfos(
+	app.Keepers.SlashingKeeper.IterateValidatorSigningInfos(
 		ctx,
 		func(addr sdk.ConsAddress, info slashingtypes.ValidatorSigningInfo) (stop bool) {
 			info.StartHeight = 0
-			app.Keepers.slashingKeeper.SetValidatorSigningInfo(ctx, addr, info)
+			app.Keepers.SlashingKeeper.SetValidatorSigningInfo(ctx, addr, info)
 			return false
 		},
 	)

--- a/app/export.go
+++ b/app/export.go
@@ -35,7 +35,7 @@ func (app *ArchwayApp) ExportAppStateAndValidators(
 		return servertypes.ExportedApp{}, err
 	}
 
-	validators, err := staking.WriteValidators(ctx, app.StakingKeeper)
+	validators, err := staking.WriteValidators(ctx, app.Keepers.StakingKeeper)
 	return servertypes.ExportedApp{
 		AppState:        appState,
 		Validators:      validators,
@@ -67,18 +67,18 @@ func (app *ArchwayApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddr
 	}
 
 	/* Just to be safe, assert the invariants on current state. */
-	app.CrisisKeeper.AssertInvariants(ctx)
+	app.Keepers.CrisisKeeper.AssertInvariants(ctx)
 
 	/* Handle fee distribution state. */
 
 	// withdraw all validator commission
-	app.StakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
-		_, _ = app.DistrKeeper.WithdrawValidatorCommission(ctx, val.GetOperator()) //nolint:errcheck
+	app.Keepers.StakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
+		_, _ = app.Keepers.DistrKeeper.WithdrawValidatorCommission(ctx, val.GetOperator()) //nolint:errcheck
 		return false
 	})
 
 	// withdraw all delegator rewards
-	dels := app.StakingKeeper.GetAllDelegations(ctx)
+	dels := app.Keepers.StakingKeeper.GetAllDelegations(ctx)
 	for _, delegation := range dels {
 		valAddr, err := sdk.ValAddressFromBech32(delegation.ValidatorAddress)
 		if err != nil {
@@ -89,28 +89,28 @@ func (app *ArchwayApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddr
 		if err != nil {
 			panic(err)
 		}
-		_, _ = app.DistrKeeper.WithdrawDelegationRewards(ctx, delAddr, valAddr) //nolint:errcheck
+		_, _ = app.Keepers.DistrKeeper.WithdrawDelegationRewards(ctx, delAddr, valAddr) //nolint:errcheck
 	}
 
 	// clear validator slash events
-	app.DistrKeeper.DeleteAllValidatorSlashEvents(ctx)
+	app.Keepers.DistrKeeper.DeleteAllValidatorSlashEvents(ctx)
 
 	// clear validator historical rewards
-	app.DistrKeeper.DeleteAllValidatorHistoricalRewards(ctx)
+	app.Keepers.DistrKeeper.DeleteAllValidatorHistoricalRewards(ctx)
 
 	// set context height to zero
 	height := ctx.BlockHeight()
 	ctx = ctx.WithBlockHeight(0)
 
 	// reinitialize all validators
-	app.StakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
+	app.Keepers.StakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
 		// donate any unwithdrawn outstanding reward fraction tokens to the community pool
-		scraps := app.DistrKeeper.GetValidatorOutstandingRewardsCoins(ctx, val.GetOperator())
-		feePool := app.DistrKeeper.GetFeePool(ctx)
+		scraps := app.Keepers.DistrKeeper.GetValidatorOutstandingRewardsCoins(ctx, val.GetOperator())
+		feePool := app.Keepers.DistrKeeper.GetFeePool(ctx)
 		feePool.CommunityPool = feePool.CommunityPool.Add(scraps...)
-		app.DistrKeeper.SetFeePool(ctx, feePool)
+		app.Keepers.DistrKeeper.SetFeePool(ctx, feePool)
 
-		app.DistrKeeper.Hooks().AfterValidatorCreated(ctx, val.GetOperator())
+		app.Keepers.DistrKeeper.Hooks().AfterValidatorCreated(ctx, val.GetOperator())
 		return false
 	})
 
@@ -124,8 +124,8 @@ func (app *ArchwayApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddr
 		if err != nil {
 			panic(err)
 		}
-		app.DistrKeeper.Hooks().BeforeDelegationCreated(ctx, delAddr, valAddr)
-		app.DistrKeeper.Hooks().AfterDelegationModified(ctx, delAddr, valAddr)
+		app.Keepers.DistrKeeper.Hooks().BeforeDelegationCreated(ctx, delAddr, valAddr)
+		app.Keepers.DistrKeeper.Hooks().AfterDelegationModified(ctx, delAddr, valAddr)
 	}
 
 	// reset context height
@@ -134,20 +134,20 @@ func (app *ArchwayApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddr
 	/* Handle staking state. */
 
 	// iterate through redelegations, reset creation height
-	app.StakingKeeper.IterateRedelegations(ctx, func(_ int64, red stakingtypes.Redelegation) (stop bool) {
+	app.Keepers.StakingKeeper.IterateRedelegations(ctx, func(_ int64, red stakingtypes.Redelegation) (stop bool) {
 		for i := range red.Entries {
 			red.Entries[i].CreationHeight = 0
 		}
-		app.StakingKeeper.SetRedelegation(ctx, red)
+		app.Keepers.StakingKeeper.SetRedelegation(ctx, red)
 		return false
 	})
 
 	// iterate through unbonding delegations, reset creation height
-	app.StakingKeeper.IterateUnbondingDelegations(ctx, func(_ int64, ubd stakingtypes.UnbondingDelegation) (stop bool) {
+	app.Keepers.StakingKeeper.IterateUnbondingDelegations(ctx, func(_ int64, ubd stakingtypes.UnbondingDelegation) (stop bool) {
 		for i := range ubd.Entries {
 			ubd.Entries[i].CreationHeight = 0
 		}
-		app.StakingKeeper.SetUnbondingDelegation(ctx, ubd)
+		app.Keepers.StakingKeeper.SetUnbondingDelegation(ctx, ubd)
 		return false
 	})
 
@@ -159,7 +159,7 @@ func (app *ArchwayApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddr
 
 	for ; iter.Valid(); iter.Next() {
 		addr := sdk.ValAddress(iter.Key()[1:])
-		validator, found := app.StakingKeeper.GetValidator(ctx, addr)
+		validator, found := app.Keepers.StakingKeeper.GetValidator(ctx, addr)
 		if !found {
 			panic("expected validator, not found")
 		}
@@ -169,13 +169,13 @@ func (app *ArchwayApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddr
 			validator.Jailed = true
 		}
 
-		app.StakingKeeper.SetValidator(ctx, validator)
+		app.Keepers.StakingKeeper.SetValidator(ctx, validator)
 		counter++
 	}
 
 	iter.Close()
 
-	_, err := app.StakingKeeper.ApplyAndReturnValidatorSetUpdates(ctx)
+	_, err := app.Keepers.StakingKeeper.ApplyAndReturnValidatorSetUpdates(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -183,11 +183,11 @@ func (app *ArchwayApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddr
 	/* Handle slashing state. */
 
 	// reset start height on signing infos
-	app.slashingKeeper.IterateValidatorSigningInfos(
+	app.Keepers.slashingKeeper.IterateValidatorSigningInfos(
 		ctx,
 		func(addr sdk.ConsAddress, info slashingtypes.ValidatorSigningInfo) (stop bool) {
 			info.StartHeight = 0
-			app.slashingKeeper.SetValidatorSigningInfo(ctx, addr, info)
+			app.Keepers.slashingKeeper.SetValidatorSigningInfo(ctx, addr, info)
 			return false
 		},
 	)

--- a/app/keepers.go
+++ b/app/keepers.go
@@ -1,0 +1,49 @@
+package app
+
+import (
+	"github.com/CosmWasm/wasmd/x/wasm"
+	rewardsKeeper "github.com/archway-network/archway/x/rewards/keeper"
+	trackingKeeper "github.com/archway-network/archway/x/tracking/keeper"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	capabilitykeeper "github.com/cosmos/cosmos-sdk/x/capability/keeper"
+	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
+	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	evidencekeeper "github.com/cosmos/cosmos-sdk/x/evidence/keeper"
+	feegrantkeeper "github.com/cosmos/cosmos-sdk/x/feegrant/keeper"
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	mintkeeper "github.com/cosmos/cosmos-sdk/x/mint/keeper"
+	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
+	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
+	icahostkeeper "github.com/cosmos/ibc-go/v4/modules/apps/27-interchain-accounts/host/keeper"
+	ibcfeekeeper "github.com/cosmos/ibc-go/v4/modules/apps/29-fee/keeper"
+	ibctransferkeeper "github.com/cosmos/ibc-go/v4/modules/apps/transfer/keeper"
+	ibckeeper "github.com/cosmos/ibc-go/v4/modules/core/keeper"
+)
+
+type ArchwayKeepers struct {
+	AccountKeeper    authkeeper.AccountKeeper
+	BankKeeper       bankkeeper.Keeper
+	CapabilityKeeper *capabilitykeeper.Keeper
+	StakingKeeper    stakingkeeper.Keeper
+	slashingKeeper   slashingkeeper.Keeper
+	MintKeeper       mintkeeper.Keeper
+	DistrKeeper      distrkeeper.Keeper
+	GovKeeper        govkeeper.Keeper
+	CrisisKeeper     crisiskeeper.Keeper
+	UpgradeKeeper    upgradekeeper.Keeper
+	ParamsKeeper     paramskeeper.Keeper
+	IBCKeeper        *ibckeeper.Keeper // IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly
+	IBCFeeKeeper     ibcfeekeeper.Keeper
+	ICAHostKeeper    icahostkeeper.Keeper
+	EvidenceKeeper   evidencekeeper.Keeper
+	TransferKeeper   ibctransferkeeper.Keeper
+	FeeGrantKeeper   feegrantkeeper.Keeper
+	AuthzKeeper      authzkeeper.Keeper
+	WASMKeeper       wasm.Keeper
+	TrackingKeeper   trackingKeeper.Keeper
+	RewardsKeeper    rewardsKeeper.Keeper
+}

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -2,8 +2,6 @@ package keepers
 
 import (
 	"github.com/CosmWasm/wasmd/x/wasm"
-	rewardsKeeper "github.com/archway-network/archway/x/rewards/keeper"
-	trackingKeeper "github.com/archway-network/archway/x/tracking/keeper"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
@@ -22,6 +20,9 @@ import (
 	ibcfeekeeper "github.com/cosmos/ibc-go/v4/modules/apps/29-fee/keeper"
 	ibctransferkeeper "github.com/cosmos/ibc-go/v4/modules/apps/transfer/keeper"
 	ibckeeper "github.com/cosmos/ibc-go/v4/modules/core/keeper"
+
+	rewardsKeeper "github.com/archway-network/archway/x/rewards/keeper"
+	trackingKeeper "github.com/archway-network/archway/x/tracking/keeper"
 )
 
 type ArchwayKeepers struct {

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -1,4 +1,4 @@
-package app
+package keepers
 
 import (
 	"github.com/CosmWasm/wasmd/x/wasm"
@@ -29,7 +29,7 @@ type ArchwayKeepers struct {
 	BankKeeper       bankkeeper.Keeper
 	CapabilityKeeper *capabilitykeeper.Keeper
 	StakingKeeper    stakingkeeper.Keeper
-	slashingKeeper   slashingkeeper.Keeper
+	SlashingKeeper   slashingkeeper.Keeper
 	MintKeeper       mintkeeper.Keeper
 	DistrKeeper      distrkeeper.Keeper
 	GovKeeper        govkeeper.Keeper

--- a/app/test_access.go
+++ b/app/test_access.go
@@ -21,11 +21,11 @@ type TestSupport struct {
 }
 
 func (s TestSupport) IBCKeeper() *ibckeeper.Keeper {
-	return s.app.IBCKeeper
+	return s.app.Keepers.IBCKeeper
 }
 
 func (s TestSupport) WasmKeeper() wasm.Keeper {
-	return s.app.WASMKeeper
+	return s.app.Keepers.WASMKeeper
 }
 
 func (s TestSupport) AppCodec() codec.Codec {
@@ -45,15 +45,15 @@ func (s TestSupport) ScopedTransferKeeper() capabilitykeeper.ScopedKeeper {
 }
 
 func (s TestSupport) StakingKeeper() stakingkeeper.Keeper {
-	return s.app.StakingKeeper
+	return s.app.Keepers.StakingKeeper
 }
 
 func (s TestSupport) BankKeeper() bankkeeper.Keeper {
-	return s.app.BankKeeper
+	return s.app.Keepers.BankKeeper
 }
 
 func (s TestSupport) TransferKeeper() ibctransferkeeper.Keeper {
-	return s.app.TransferKeeper
+	return s.app.Keepers.TransferKeeper
 }
 
 func (s TestSupport) GetBaseApp() *baseapp.BaseApp {

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -243,7 +243,7 @@ func createIncrementalAccounts(accNum int) []sdk.AccAddress {
 
 // AddTestAddrsFromPubKeys adds the addresses into the ArchwayApp providing only the public keys.
 func AddTestAddrsFromPubKeys(app *ArchwayApp, ctx sdk.Context, pubKeys []cryptotypes.PubKey, accAmt sdk.Int) {
-	initCoins := sdk.NewCoins(sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), accAmt))
+	initCoins := sdk.NewCoins(sdk.NewCoin(app.Keepers.StakingKeeper.BondDenom(ctx), accAmt))
 
 	for _, pk := range pubKeys {
 		initAccountWithCoins(app, ctx, sdk.AccAddress(pk.Address()), initCoins)
@@ -265,7 +265,7 @@ func AddTestAddrsIncremental(app *ArchwayApp, ctx sdk.Context, accNum int, accAm
 func addTestAddrs(app *ArchwayApp, ctx sdk.Context, accNum int, accAmt sdk.Int, strategy GenerateAccountStrategy) []sdk.AccAddress {
 	testAddrs := strategy(accNum)
 
-	initCoins := sdk.NewCoins(sdk.NewCoin(app.StakingKeeper.BondDenom(ctx), accAmt))
+	initCoins := sdk.NewCoins(sdk.NewCoin(app.Keepers.StakingKeeper.BondDenom(ctx), accAmt))
 
 	// fill all the addresses with some coins, set the loose pool tokens simultaneously
 	for _, addr := range testAddrs {
@@ -276,12 +276,12 @@ func addTestAddrs(app *ArchwayApp, ctx sdk.Context, accNum int, accAmt sdk.Int, 
 }
 
 func initAccountWithCoins(app *ArchwayApp, ctx sdk.Context, addr sdk.AccAddress, coins sdk.Coins) {
-	err := app.BankKeeper.MintCoins(ctx, minttypes.ModuleName, coins)
+	err := app.Keepers.BankKeeper.MintCoins(ctx, minttypes.ModuleName, coins)
 	if err != nil {
 		panic(err)
 	}
 
-	err = app.BankKeeper.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, addr, coins)
+	err = app.Keepers.BankKeeper.SendCoinsFromModuleToAccount(ctx, minttypes.ModuleName, addr, coins)
 	if err != nil {
 		panic(err)
 	}
@@ -322,7 +322,7 @@ func TestAddr(addr, bech string) (sdk.AccAddress, error) {
 // CheckBalance checks the balance of an account.
 func CheckBalance(t *testing.T, app *ArchwayApp, addr sdk.AccAddress, balances sdk.Coins) {
 	ctxCheck := app.BaseApp.NewContext(true, tmproto.Header{})
-	require.True(t, balances.IsEqual(app.BankKeeper.GetAllBalances(ctxCheck, addr)))
+	require.True(t, balances.IsEqual(app.Keepers.BankKeeper.GetAllBalances(ctxCheck, addr)))
 }
 
 const DefaultGas = 1200000

--- a/app/upgrades/06/upgrades.go
+++ b/app/upgrades/06/upgrades.go
@@ -4,10 +4,10 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	ibcfeetypes "github.com/cosmos/ibc-go/v4/modules/apps/29-fee/types"
 
+	"github.com/archway-network/archway/app/keepers"
 	"github.com/archway-network/archway/app/upgrades"
 )
 
@@ -15,7 +15,7 @@ const Name = "v0.6.0"
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName: Name,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, _ keeper.AccountKeeper) upgradetypes.UpgradeHandler {
+	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, _ keepers.ArchwayKeepers) upgradetypes.UpgradeHandler {
 		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 			return mm.RunMigrations(ctx, cfg, fromVM)
 		}

--- a/app/upgrades/1_0_0_rc_4/upgrades.go
+++ b/app/upgrades/1_0_0_rc_4/upgrades.go
@@ -4,9 +4,9 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	"github.com/archway-network/archway/app/keepers"
 	"github.com/archway-network/archway/app/upgrades"
 )
 
@@ -14,7 +14,7 @@ const Name = "v1.0.0-rc.4"
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName: Name,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, _ keeper.AccountKeeper) upgradetypes.UpgradeHandler {
+	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, _ keepers.ArchwayKeepers) upgradetypes.UpgradeHandler {
 		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 			return mm.RunMigrations(ctx, cfg, fromVM)
 		}

--- a/app/upgrades/2_0_0/upgrades.go
+++ b/app/upgrades/2_0_0/upgrades.go
@@ -5,7 +5,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 
-	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
@@ -17,6 +16,7 @@ import (
 	icahosttypes "github.com/cosmos/ibc-go/v4/modules/apps/27-interchain-accounts/host/types"
 	icatypes "github.com/cosmos/ibc-go/v4/modules/apps/27-interchain-accounts/types"
 
+	"github.com/archway-network/archway/app/keepers"
 	"github.com/archway-network/archway/app/upgrades"
 )
 
@@ -24,7 +24,7 @@ const Name = "v2.0.0"
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName: Name,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, _ keeper.AccountKeeper) upgradetypes.UpgradeHandler {
+	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, _ keepers.ArchwayKeepers) upgradetypes.UpgradeHandler {
 		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 
 			// Set Initial Consensus Version

--- a/app/upgrades/3_0_0/upgrades.go
+++ b/app/upgrades/3_0_0/upgrades.go
@@ -4,9 +4,9 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	"github.com/archway-network/archway/app/keepers"
 	"github.com/archway-network/archway/app/upgrades"
 )
 
@@ -14,7 +14,7 @@ const Name = "v3.0.0"
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName: Name,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, _ keeper.AccountKeeper) upgradetypes.UpgradeHandler {
+	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, _ keepers.ArchwayKeepers) upgradetypes.UpgradeHandler {
 		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 			return mm.RunMigrations(ctx, cfg, fromVM)
 		}

--- a/app/upgrades/4_0_0/upgrades.go
+++ b/app/upgrades/4_0_0/upgrades.go
@@ -4,9 +4,9 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	"github.com/archway-network/archway/app/keepers"
 	"github.com/archway-network/archway/app/upgrades"
 )
 
@@ -14,7 +14,7 @@ const Name = "v4.0.0"
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName: Name,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, _ keeper.AccountKeeper) upgradetypes.UpgradeHandler {
+	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, _ keepers.ArchwayKeepers) upgradetypes.UpgradeHandler {
 		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 			return mm.RunMigrations(ctx, cfg, fromVM)
 		}

--- a/app/upgrades/4_0_2/upgrades.go
+++ b/app/upgrades/4_0_2/upgrades.go
@@ -6,10 +6,10 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	"github.com/archway-network/archway/app/keepers"
 	"github.com/archway-network/archway/app/upgrades"
 )
 
@@ -17,8 +17,9 @@ const Name = "v4.0.2"
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName: Name,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, accountKeeper keeper.AccountKeeper) upgradetypes.UpgradeHandler {
+	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, keepers keepers.ArchwayKeepers) upgradetypes.UpgradeHandler {
 		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			accountKeeper := keepers.AccountKeeper
 			fcAccount := accountKeeper.GetModuleAccount(ctx, authtypes.FeeCollectorName)
 			account, ok := fcAccount.(*authtypes.ModuleAccount)
 			if !ok {

--- a/app/upgrades/4_0_2/upgrades_test.go
+++ b/app/upgrades/4_0_2/upgrades_test.go
@@ -31,7 +31,6 @@ const (
 )
 
 func (suite *UpgradeTestSuite) TestUpgrade() {
-	keepers := suite.archway.GetApp().Keepers
 	testCases := []struct {
 		name         string
 		pre_upgrade  func()
@@ -40,7 +39,7 @@ func (suite *UpgradeTestSuite) TestUpgrade() {
 		{
 			"Feecollector does not have burn permissions, we ensure upgrade happens and account gets the burn permissions",
 			func() {
-				accountKeeper := keepers.AccountKeeper
+				accountKeeper := suite.archway.GetApp().Keepers.AccountKeeper
 				fcAccount := accountKeeper.GetModuleAccount(suite.archway.GetContext(), authtypes.FeeCollectorName)
 
 				account, ok := fcAccount.(*authtypes.ModuleAccount)
@@ -52,7 +51,7 @@ func (suite *UpgradeTestSuite) TestUpgrade() {
 				suite.Require().False(fcAccount.HasPermission(authtypes.Burner))
 			},
 			func() {
-				accountKeeper := keepers.AccountKeeper
+				accountKeeper := suite.archway.GetApp().Keepers.AccountKeeper
 				fcAccount := accountKeeper.GetModuleAccount(suite.archway.GetContext(), authtypes.FeeCollectorName)
 				suite.Require().True(fcAccount.HasPermission(authtypes.Burner))
 			},
@@ -60,12 +59,12 @@ func (suite *UpgradeTestSuite) TestUpgrade() {
 		{
 			"Feecollector already has burn permissions, we ensure upgrade happens smoothly",
 			func() {
-				accountKeeper := keepers.AccountKeeper
+				accountKeeper := suite.archway.GetApp().Keepers.AccountKeeper
 				fcAccount := accountKeeper.GetModuleAccount(suite.archway.GetContext(), authtypes.FeeCollectorName)
 				suite.Require().True(fcAccount.HasPermission(authtypes.Burner))
 			},
 			func() {
-				accountKeeper := keepers.AccountKeeper
+				accountKeeper := suite.archway.GetApp().Keepers.AccountKeeper
 				fcAccount := accountKeeper.GetModuleAccount(suite.archway.GetContext(), authtypes.FeeCollectorName)
 				suite.Require().True(fcAccount.HasPermission(authtypes.Burner))
 			},
@@ -80,7 +79,7 @@ func (suite *UpgradeTestSuite) TestUpgrade() {
 
 			ctx := suite.archway.GetContext().WithBlockHeight(dummyUpgradeHeight - 1)
 			plan := upgradetypes.Plan{Name: "v4.0.2", Height: dummyUpgradeHeight}
-			upgradekeeper := keepers.UpgradeKeeper
+			upgradekeeper := suite.archway.GetApp().Keepers.UpgradeKeeper
 			err := upgradekeeper.ScheduleUpgrade(ctx, plan)
 			suite.Require().NoError(err)
 			_, exists := upgradekeeper.GetUpgradePlan(ctx)

--- a/app/upgrades/4_0_2/upgrades_test.go
+++ b/app/upgrades/4_0_2/upgrades_test.go
@@ -31,6 +31,7 @@ const (
 )
 
 func (suite *UpgradeTestSuite) TestUpgrade() {
+	keepers := suite.archway.GetApp().Keepers
 	testCases := []struct {
 		name         string
 		pre_upgrade  func()
@@ -39,7 +40,7 @@ func (suite *UpgradeTestSuite) TestUpgrade() {
 		{
 			"Feecollector does not have burn permissions, we ensure upgrade happens and account gets the burn permissions",
 			func() {
-				accountKeeper := suite.archway.GetApp().AccountKeeper
+				accountKeeper := keepers.AccountKeeper
 				fcAccount := accountKeeper.GetModuleAccount(suite.archway.GetContext(), authtypes.FeeCollectorName)
 
 				account, ok := fcAccount.(*authtypes.ModuleAccount)
@@ -51,7 +52,7 @@ func (suite *UpgradeTestSuite) TestUpgrade() {
 				suite.Require().False(fcAccount.HasPermission(authtypes.Burner))
 			},
 			func() {
-				accountKeeper := suite.archway.GetApp().AccountKeeper
+				accountKeeper := keepers.AccountKeeper
 				fcAccount := accountKeeper.GetModuleAccount(suite.archway.GetContext(), authtypes.FeeCollectorName)
 				suite.Require().True(fcAccount.HasPermission(authtypes.Burner))
 			},
@@ -59,12 +60,12 @@ func (suite *UpgradeTestSuite) TestUpgrade() {
 		{
 			"Feecollector already has burn permissions, we ensure upgrade happens smoothly",
 			func() {
-				accountKeeper := suite.archway.GetApp().AccountKeeper
+				accountKeeper := keepers.AccountKeeper
 				fcAccount := accountKeeper.GetModuleAccount(suite.archway.GetContext(), authtypes.FeeCollectorName)
 				suite.Require().True(fcAccount.HasPermission(authtypes.Burner))
 			},
 			func() {
-				accountKeeper := suite.archway.GetApp().AccountKeeper
+				accountKeeper := keepers.AccountKeeper
 				fcAccount := accountKeeper.GetModuleAccount(suite.archway.GetContext(), authtypes.FeeCollectorName)
 				suite.Require().True(fcAccount.HasPermission(authtypes.Burner))
 			},
@@ -79,7 +80,7 @@ func (suite *UpgradeTestSuite) TestUpgrade() {
 
 			ctx := suite.archway.GetContext().WithBlockHeight(dummyUpgradeHeight - 1)
 			plan := upgradetypes.Plan{Name: "v4.0.2", Height: dummyUpgradeHeight}
-			upgradekeeper := suite.archway.GetApp().UpgradeKeeper
+			upgradekeeper := keepers.UpgradeKeeper
 			err := upgradekeeper.ScheduleUpgrade(ctx, plan)
 			suite.Require().NoError(err)
 			_, exists := upgradekeeper.GetUpgradePlan(ctx)

--- a/app/upgrades/latest/upgrades.go
+++ b/app/upgrades/latest/upgrades.go
@@ -4,9 +4,9 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	"github.com/archway-network/archway/app/keepers"
 	"github.com/archway-network/archway/app/upgrades"
 )
 
@@ -25,7 +25,7 @@ const NameAsciiArt = `
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName: Name,
-	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, accountKeeper keeper.AccountKeeper) upgradetypes.UpgradeHandler {
+	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, keepers keepers.ArchwayKeepers) upgradetypes.UpgradeHandler {
 		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 			migrations, err := mm.RunMigrations(ctx, cfg, fromVM)
 			if err != nil {

--- a/app/upgrades/upgrades.go
+++ b/app/upgrades/upgrades.go
@@ -1,10 +1,11 @@
 package upgrades
 
 import (
-	"github.com/archway-network/archway/app/keepers"
 	"github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	"github.com/archway-network/archway/app/keepers"
 )
 
 // Upgrade defines a struct containing necessary fields that a SoftwareUpgradeProposal

--- a/app/upgrades/upgrades.go
+++ b/app/upgrades/upgrades.go
@@ -1,9 +1,9 @@
 package upgrades
 
 import (
+	"github.com/archway-network/archway/app/keepers"
 	"github.com/cosmos/cosmos-sdk/store/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
 
@@ -16,7 +16,7 @@ type Upgrade struct {
 	UpgradeName string
 
 	// CreateUpgradeHandler defines the function that creates an upgrade handler
-	CreateUpgradeHandler func(*module.Manager, module.Configurator, keeper.AccountKeeper) upgradetypes.UpgradeHandler
+	CreateUpgradeHandler func(*module.Manager, module.Configurator, keepers.ArchwayKeepers) upgradetypes.UpgradeHandler
 
 	// Store upgrades, should be used for any new modules introduced, new modules deleted, or store names renamed.
 	StoreUpgrades types.StoreUpgrades

--- a/e2e/gastracking_test.go
+++ b/e2e/gastracking_test.go
@@ -45,7 +45,8 @@ func (s *E2ETestSuite) TestGasTrackingAndRewardsDistribution() {
 		// Set default Tx fee for non-manual transaction like Upload / Instantiate
 		e2eTesting.WithDefaultFeeAmount("500000000000000"),
 	)
-	trackingKeeper, rewardsKeeper := chain.GetApp().TrackingKeeper, chain.GetApp().RewardsKeeper
+	keepers := chain.GetApp().Keepers
+	trackingKeeper, rewardsKeeper := keepers.TrackingKeeper, keepers.RewardsKeeper
 
 	senderAcc := chain.GetAccount(0)
 	contractAddr := s.VoterUploadAndInstantiate(chain, senderAcc)
@@ -86,7 +87,7 @@ func (s *E2ETestSuite) TestGasTrackingAndRewardsDistribution() {
 	rewardsAccInitialBalance := sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdk.NewInt(1).Mul(archway.DefaultPowerReduction)))
 	{
 		s.Require().NoError(
-			chain.GetApp().BankKeeper.SendCoins(
+			keepers.BankKeeper.SendCoins(
 				chain.GetContext(),
 				senderAcc.Address,
 				rewardsAcc.Address,
@@ -118,10 +119,10 @@ func (s *E2ETestSuite) TestGasTrackingAndRewardsDistribution() {
 	{
 		ctx := chain.GetContext()
 
-		mintKeeper := chain.GetApp().MintKeeper
+		mintKeeper := keepers.MintKeeper
 		mintParams := mintKeeper.GetParams(ctx)
 
-		mintedCoin := chain.GetApp().MintKeeper.GetMinter(ctx).BlockProvision(mintParams)
+		mintedCoin := keepers.MintKeeper.GetMinter(ctx).BlockProvision(mintParams)
 		inflationRewards, _ := pkg.SplitCoins(sdk.NewCoins(mintedCoin), inflationRewardsRatio)
 		s.Require().Len(inflationRewards, 1)
 		blockInflationRewardsExpected = inflationRewards[0]

--- a/e2e/rewards_test.go
+++ b/e2e/rewards_test.go
@@ -49,7 +49,8 @@ func (s *E2ETestSuite) TestRewardsWithdrawProfitAndFees() {
 			uint64(60*60*8766/1),      // 1 seconds block time
 		),
 	)
-	trackingKeeper, rewardsKeeper := chain.GetApp().TrackingKeeper, chain.GetApp().RewardsKeeper
+	keepers := chain.GetApp().Keepers
+	trackingKeeper, rewardsKeeper := keepers.TrackingKeeper, keepers.RewardsKeeper
 	chain.NextBlock(0)
 
 	// Upload a new contract and set its address as the rewardsAddress
@@ -172,8 +173,8 @@ func (s *E2ETestSuite) TestRewardsWithdrawProfitAndFees() {
 		}
 
 		// Mint rewards coins
-		s.Require().NoError(chain.GetApp().MintKeeper.MintCoins(ctx, coinsToMint))
-		s.Require().NoError(chain.GetApp().BankKeeper.SendCoinsFromModuleToModule(ctx, mintTypes.ModuleName, rewardsTypes.ContractRewardCollector, coinsToMint))
+		s.Require().NoError(keepers.MintKeeper.MintCoins(ctx, coinsToMint))
+		s.Require().NoError(keepers.BankKeeper.SendCoinsFromModuleToModule(ctx, mintTypes.ModuleName, rewardsTypes.ContractRewardCollector, coinsToMint))
 
 		// Invariants check (just in case)
 		chain.NextBlock(0)
@@ -242,7 +243,8 @@ func (s *E2ETestSuite) TestRewardsParamMaxWithdrawRecordsLimit() {
 		e2eTesting.WithBlockGasLimit(100_000_000),
 		e2eTesting.WithMaxWithdrawRecords(rewardsTypes.MaxWithdrawRecordsParamLimit),
 	)
-	bankKeeper, mintKeeper, rewardsKeeper := chain.GetApp().BankKeeper, chain.GetApp().MintKeeper, chain.GetApp().RewardsKeeper
+	keepers := chain.GetApp().Keepers
+	bankKeeper, mintKeeper, rewardsKeeper := keepers.BankKeeper, keepers.MintKeeper, keepers.RewardsKeeper
 
 	// Upload a new contract and set its address as the rewardsAddress
 	senderAcc := chain.GetAccount(0)
@@ -313,7 +315,8 @@ func (s *E2ETestSuite) TestRewardsRecordsQueryLimit() {
 	rewardsTypes.MaxRecordsQueryLimit = uint64(7716) // an actual value is (thisValue - 1), refer to the query below
 
 	chain := e2eTesting.NewTestChain(s.T(), 1)
-	bankKeeper, mintKeeper, rewardsKeeper := chain.GetApp().BankKeeper, chain.GetApp().MintKeeper, chain.GetApp().RewardsKeeper
+	keepers := chain.GetApp().Keepers
+	bankKeeper, mintKeeper, rewardsKeeper := keepers.BankKeeper, keepers.MintKeeper, keepers.RewardsKeeper
 
 	// Upload a new contract and set its address as the rewardsAddress
 	senderAcc := chain.GetAccount(0)
@@ -398,7 +401,7 @@ func (s *E2ETestSuite) TestTXFailsAfterAnteHandler() {
 			uint64(60*60*8766/1),      // 1 seconds block time
 		),
 	)
-	rewardsKeeper := chain.GetApp().RewardsKeeper
+	rewardsKeeper := chain.GetApp().Keepers.RewardsKeeper
 
 	// Upload a new contract and set its address as the rewardsAddress
 	senderAcc := chain.GetAccount(0)
@@ -484,7 +487,7 @@ func (s *E2ETestSuite) TestRewardsFlatFees() {
 			uint64(60*60*8766/1),      // 1 seconds block time
 		),
 	)
-	rewardsKeeper := chain.GetApp().RewardsKeeper
+	rewardsKeeper := chain.GetApp().Keepers.RewardsKeeper
 
 	// Upload a new contract and set its address as the rewardsAddress
 	senderAcc := chain.GetAccount(0)
@@ -629,7 +632,7 @@ func (s *E2ETestSuite) TestSubMsgRevert() {
 			uint64(60*60*8766/1),      // 1 seconds block time
 		),
 	)
-	rewardsKeeper := chain.GetApp().RewardsKeeper
+	rewardsKeeper := chain.GetApp().Keepers.RewardsKeeper
 
 	// Upload a new contract and set its address as the rewardsAddress
 	senderAcc := chain.GetAccount(0)
@@ -677,7 +680,7 @@ func (s *E2ETestSuite) TestSubMsgRevert() {
 
 		return
 	}
-	rk := chain.GetApp().RewardsKeeper
+	rk := chain.GetApp().Keepers.RewardsKeeper
 
 	// send a message that passes the ante handler but not the wasm execution step
 	sendMsg(&wasmdTypes.MsgExecuteContract{

--- a/e2e/testing/chain.go
+++ b/e2e/testing/chain.go
@@ -280,15 +280,15 @@ func (chain *TestChain) GetAccount(idx int) Account {
 
 // GetBalance returns the balance of the given account.
 func (chain *TestChain) GetBalance(accAddr sdk.AccAddress) sdk.Coins {
-	return chain.app.BankKeeper.GetAllBalances(chain.GetContext(), accAddr)
+	return chain.app.Keepers.BankKeeper.GetAllBalances(chain.GetContext(), accAddr)
 }
 
 // GetModuleBalance returns the balance of the given module.
 func (chain *TestChain) GetModuleBalance(moduleName string) sdk.Coins {
 	ctx := chain.GetContext()
-	moduleAcc := chain.app.AccountKeeper.GetModuleAccount(ctx, moduleName)
+	moduleAcc := chain.app.Keepers.AccountKeeper.GetModuleAccount(ctx, moduleName)
 
-	return chain.app.BankKeeper.GetAllBalances(chain.GetContext(), moduleAcc.GetAddress())
+	return chain.app.Keepers.BankKeeper.GetAllBalances(chain.GetContext(), moduleAcc.GetAddress())
 }
 
 // GetContext returns a context for the current block.
@@ -326,7 +326,7 @@ func (chain *TestChain) GetBlockHeight() int64 {
 
 // GetUnbondingTime returns x/staking validator unbonding time.
 func (chain *TestChain) GetUnbondingTime() time.Duration {
-	return chain.app.StakingKeeper.UnbondingTime(chain.GetContext())
+	return chain.app.Keepers.StakingKeeper.UnbondingTime(chain.GetContext())
 }
 
 // GetApp returns the application.
@@ -470,7 +470,7 @@ func (chain *TestChain) SendMsgsRaw(senderAcc Account, msgs []sdk.Msg, opts ...S
 	options := chain.buildSendMsgOptions(opts...)
 
 	// Get the sender account
-	senderAccI := chain.app.AccountKeeper.GetAccount(chain.GetContext(), senderAcc.Address)
+	senderAccI := chain.app.Keepers.AccountKeeper.GetAccount(chain.GetContext(), senderAcc.Address)
 	require.NotNil(t, senderAccI)
 
 	// Build and sign Tx

--- a/e2e/testing/chain_ops.go
+++ b/e2e/testing/chain_ops.go
@@ -13,7 +13,7 @@ func (chain *TestChain) ExecuteGovProposal(proposerAcc Account, expPass bool, pr
 	require.NotNil(t, proposalContent)
 
 	// Get params
-	k := chain.app.GovKeeper
+	k := chain.app.Keepers.GovKeeper
 	depositCoin := k.GetDepositParams(chain.GetContext()).MinDeposit
 	votingDur := k.GetVotingParams(chain.GetContext()).VotingPeriod
 

--- a/e2e/testing/chain_ops_contract.go
+++ b/e2e/testing/chain_ops_contract.go
@@ -81,7 +81,7 @@ func (chain *TestChain) SmartQueryContract(contractAddr sdk.AccAddress, expPass 
 	reqBz, err := msg.MarshalJSON()
 	require.NoError(t, err)
 
-	resp, err := chain.app.WASMKeeper.QuerySmart(chain.GetContext(), contractAddr, reqBz)
+	resp, err := chain.app.Keepers.WASMKeeper.QuerySmart(chain.GetContext(), contractAddr, reqBz)
 	if expPass {
 		require.NoError(t, err)
 		return resp, nil
@@ -95,7 +95,7 @@ func (chain *TestChain) SmartQueryContract(contractAddr sdk.AccAddress, expPass 
 func (chain *TestChain) GetContractInfo(contractAddr sdk.AccAddress) wasmdTypes.ContractInfo {
 	t := chain.t
 
-	info := chain.app.WASMKeeper.GetContractInfo(chain.GetContext(), contractAddr)
+	info := chain.app.Keepers.WASMKeeper.GetContractInfo(chain.GetContext(), contractAddr)
 	require.NotNil(t, info)
 
 	return *info
@@ -105,7 +105,7 @@ func (chain *TestChain) GetContractInfo(contractAddr sdk.AccAddress) wasmdTypes.
 func (chain *TestChain) GetContractMetadata(contractAddr sdk.AccAddress) rewardsTypes.ContractMetadata {
 	t := chain.t
 
-	state := chain.app.RewardsKeeper.GetState().ContractMetadataState(chain.GetContext())
+	state := chain.app.Keepers.RewardsKeeper.GetState().ContractMetadataState(chain.GetContext())
 
 	metadata, found := state.GetContractMetadata(contractAddr)
 	require.True(t, found)

--- a/e2e/testing/chain_ops_ibc.go
+++ b/e2e/testing/chain_ops_ibc.go
@@ -26,7 +26,7 @@ import (
 // Used to send IBC ConnectionOpenInit msg.
 func (chain *TestChain) GetMerklePrefix() commitmentTypes.MerklePrefix {
 	return commitmentTypes.NewMerklePrefix(
-		chain.app.IBCKeeper.ConnectionKeeper.GetCommitmentPrefix().Bytes(),
+		chain.app.Keepers.IBCKeeper.ConnectionKeeper.GetCommitmentPrefix().Bytes(),
 	)
 }
 
@@ -35,7 +35,7 @@ func (chain *TestChain) GetMerklePrefix() commitmentTypes.MerklePrefix {
 func (chain *TestChain) GetClientState(clientID string) exported.ClientState {
 	t := chain.t
 
-	clientState, found := chain.app.IBCKeeper.ClientKeeper.GetClientState(chain.GetContext(), clientID)
+	clientState, found := chain.app.Keepers.IBCKeeper.ClientKeeper.GetClientState(chain.GetContext(), clientID)
 	require.True(t, found)
 
 	return clientState
@@ -52,7 +52,7 @@ func (chain *TestChain) GetCurrentValSet() tmTypes.ValidatorSet {
 func (chain *TestChain) GetValSetAtHeight(height int64) tmTypes.ValidatorSet {
 	t := chain.t
 
-	histInfo, ok := chain.app.StakingKeeper.GetHistoricalInfo(chain.GetContext(), height)
+	histInfo, ok := chain.app.Keepers.StakingKeeper.GetHistoricalInfo(chain.GetContext(), height)
 	require.True(t, ok)
 
 	validators := stakingTypes.Validators(histInfo.Valset)
@@ -101,14 +101,14 @@ func (chain *TestChain) SendIBCPacket(packet exported.PacketI) {
 	cap, ok := chain.app.ScopedIBCKeeper.GetCapability(chain.GetContext(), capPath)
 	require.True(t, ok)
 
-	require.NoError(t, chain.app.IBCKeeper.ChannelKeeper.SendPacket(chain.GetContext(), cap, packet))
+	require.NoError(t, chain.app.Keepers.IBCKeeper.ChannelKeeper.SendPacket(chain.GetContext(), cap, packet))
 
 	chain.NextBlock(0)
 }
 
 // GetIBCPacketCommitment returns an IBC packet commitment hash (nil if not committed).
 func (chain *TestChain) GetIBCPacketCommitment(packet channelTypes.Packet) []byte {
-	return chain.app.IBCKeeper.ChannelKeeper.GetPacketCommitment(
+	return chain.app.Keepers.IBCKeeper.ChannelKeeper.GetPacketCommitment(
 		chain.GetContext(),
 		packet.GetSourcePort(), packet.GetSourceChannel(), packet.GetSequence(),
 	)
@@ -118,7 +118,7 @@ func (chain *TestChain) GetIBCPacketCommitment(packet channelTypes.Packet) []byt
 func (chain *TestChain) GetNextIBCPacketSequence(portID, channelID string) uint64 {
 	t := chain.t
 
-	seq, ok := chain.app.IBCKeeper.ChannelKeeper.GetNextSequenceRecv(chain.GetContext(), portID, channelID)
+	seq, ok := chain.app.Keepers.IBCKeeper.ChannelKeeper.GetNextSequenceRecv(chain.GetContext(), portID, channelID)
 	require.True(t, ok)
 
 	return seq

--- a/e2e/voter_test.go
+++ b/e2e/voter_test.go
@@ -995,7 +995,7 @@ func (s *E2ETestSuite) TestVoter_WASMBindingsRewardsRecordsQuery() {
 		s.VoterNewVoting(chain, contractAddr, acc, "Test", []string{"a", "b"}, 1*time.Hour)
 		s.VoterVote(chain, contractAddr, acc, 0, "a", true)
 
-		recordsExpected = chain.GetApp().RewardsKeeper.GetState().RewardsRecord(chain.GetContext()).GetRewardsRecordByRewardsAddress(contractAddr)
+		recordsExpected = chain.GetApp().Keepers.RewardsKeeper.GetState().RewardsRecord(chain.GetContext()).GetRewardsRecordByRewardsAddress(contractAddr)
 		s.Require().Len(recordsExpected, 2)
 	}
 
@@ -1099,7 +1099,7 @@ func (s *E2ETestSuite) TestVoter_WASMBindingsWithdrawRewards() {
 		s.VoterVote(chain, contractAddr, acc2, 0, "b", false)
 		s.VoterVote(chain, contractAddr, acc3, 0, "c", true)
 
-		recordsExpected = chain.GetApp().RewardsKeeper.GetState().RewardsRecord(chain.GetContext()).GetRewardsRecordByRewardsAddress(contractAddr)
+		recordsExpected = chain.GetApp().Keepers.RewardsKeeper.GetState().RewardsRecord(chain.GetContext()).GetRewardsRecordByRewardsAddress(contractAddr)
 		s.Require().Len(recordsExpected, 4)
 
 		for _, record := range recordsExpected {

--- a/wasmbinding/gov/query_test.go
+++ b/wasmbinding/gov/query_test.go
@@ -18,7 +18,7 @@ import (
 func TestGovWASMBindings(t *testing.T) {
 	// Setup
 	chain := e2eTesting.NewTestChain(t, 1)
-	ctx, keeper := chain.GetContext(), chain.GetApp().GovKeeper
+	ctx, keeper := chain.GetContext(), chain.GetApp().Keepers.GovKeeper
 
 	// Create custom plugins
 	queryPlugin := gov.NewQueryHandler(keeper)

--- a/wasmbinding/integration_test.go
+++ b/wasmbinding/integration_test.go
@@ -19,7 +19,7 @@ func TestGovQuerier(t *testing.T) {
 	// we create a vote which only contains the address of account 1
 	// and we check if the contract can see the vote and match the result
 	chain := e2eTesting.NewTestChain(t, 1)
-	chain.GetApp().GovKeeper.SetVote(chain.GetContext(), sdkGov.Vote{
+	chain.GetApp().Keepers.GovKeeper.SetVote(chain.GetContext(), sdkGov.Vote{
 		ProposalId: 1,
 		Voter:      chain.GetAccount(1).Address.String(),
 		Option:     0,

--- a/wasmbinding/plugin_test.go
+++ b/wasmbinding/plugin_test.go
@@ -26,8 +26,9 @@ func TestWASMBindingPlugins(t *testing.T) {
 	ctx := chain.GetContext()
 
 	// Create custom plugins
-	rewardsKeeper := chain.GetApp().RewardsKeeper
-	govKeeper := chain.GetApp().GovKeeper
+	keepers := chain.GetApp().Keepers
+	rewardsKeeper := keepers.RewardsKeeper
+	govKeeper := keepers.GovKeeper
 	msgPlugin := wasmbinding.BuildWasmMsgDecorator(rewardsKeeper)
 	queryPlugin := wasmbinding.BuildWasmQueryPlugin(rewardsKeeper, govKeeper)
 

--- a/wasmbinding/rewards/common_test.go
+++ b/wasmbinding/rewards/common_test.go
@@ -37,8 +37,9 @@ func TestRewardsWASMBindings(t *testing.T) {
 	contractViewer.AddContractAdmin(contractXAddr.String(), acc.Address.String())
 	contractViewer.AddContractAdmin(contractYAddr.String(), acc.Address.String())
 
-	chain.GetApp().RewardsKeeper.SetContractInfoViewer(contractViewer)
-	ctx, keeper := chain.GetContext(), chain.GetApp().RewardsKeeper
+	keepers := chain.GetApp().Keepers
+	ctx, keeper := chain.GetContext(), keepers.RewardsKeeper
+	keeper.SetContractInfoViewer(contractViewer)
 
 	// Create custom plugins
 	queryPlugin := rewards.NewQueryHandler(keeper)
@@ -329,8 +330,8 @@ func TestRewardsWASMBindings(t *testing.T) {
 	keeper.GetState().RewardsRecord(ctx).CreateRewardsRecord(contractAddr, record1RewardsExpected, ctx.BlockHeight(), ctx.BlockTime())
 	keeper.GetState().RewardsRecord(ctx).CreateRewardsRecord(contractAddr, record2RewardsExpected, ctx.BlockHeight(), ctx.BlockTime())
 	keeper.GetState().RewardsRecord(ctx).CreateRewardsRecord(contractAddr, record3RewardsExpected, ctx.BlockHeight(), ctx.BlockTime())
-	require.NoError(t, chain.GetApp().MintKeeper.MintCoins(ctx, recordsRewards))
-	require.NoError(t, chain.GetApp().BankKeeper.SendCoinsFromModuleToModule(ctx, mintTypes.ModuleName, rewardsTypes.ContractRewardCollector, recordsRewards))
+	require.NoError(t, keepers.MintKeeper.MintCoins(ctx, recordsRewards))
+	require.NoError(t, keepers.BankKeeper.SendCoinsFromModuleToModule(ctx, mintTypes.ModuleName, rewardsTypes.ContractRewardCollector, recordsRewards))
 
 	// Query available rewards
 	t.Run("Query new rewards", func(t *testing.T) {

--- a/x/rewards/keeper/common_test.go
+++ b/x/rewards/keeper/common_test.go
@@ -33,20 +33,21 @@ func (s *KeeperTestSuite) SetupWithdrawTest(testData []withdrawTestRecordData) {
 	// Create test records
 	for _, testRecord := range testData {
 		ctx := s.chain.GetContext()
+		keepers := s.chain.GetApp().Keepers
 
 		// Get rid of the current inflationary rewards for the current block (otherwise the invariant fails)
-		blockRewards, found := s.chain.GetApp().RewardsKeeper.GetState().BlockRewardsState(ctx).GetBlockRewards(ctx.BlockHeight())
+		blockRewards, found := keepers.RewardsKeeper.GetState().BlockRewardsState(ctx).GetBlockRewards(ctx.BlockHeight())
 		s.Require().True(found)
-		s.Require().NoError(s.chain.GetApp().BankKeeper.SendCoinsFromModuleToModule(ctx, rewardsTypes.ContractRewardCollector, rewardsTypes.TreasuryCollector, sdk.Coins{blockRewards.InflationRewards}))
-		s.chain.GetApp().RewardsKeeper.GetState().BlockRewardsState(ctx).CreateBlockRewards(ctx.BlockHeight(), sdk.NewCoin(sdk.DefaultBondDenom, sdk.ZeroInt()), 0)
+		s.Require().NoError(keepers.BankKeeper.SendCoinsFromModuleToModule(ctx, rewardsTypes.ContractRewardCollector, rewardsTypes.TreasuryCollector, sdk.Coins{blockRewards.InflationRewards}))
+		keepers.RewardsKeeper.GetState().BlockRewardsState(ctx).CreateBlockRewards(ctx.BlockHeight(), sdk.NewCoin(sdk.DefaultBondDenom, sdk.ZeroInt()), 0)
 
 		// Mint rewards for the current record
 		rewardsToMint := testRecord.Rewards
-		s.Require().NoError(s.chain.GetApp().MintKeeper.MintCoins(ctx, rewardsToMint))
-		s.Require().NoError(s.chain.GetApp().BankKeeper.SendCoinsFromModuleToModule(ctx, mintTypes.ModuleName, rewardsTypes.ContractRewardCollector, rewardsToMint))
+		s.Require().NoError(keepers.MintKeeper.MintCoins(ctx, rewardsToMint))
+		s.Require().NoError(keepers.BankKeeper.SendCoinsFromModuleToModule(ctx, mintTypes.ModuleName, rewardsTypes.ContractRewardCollector, rewardsToMint))
 
 		// Create the record
-		s.chain.GetApp().RewardsKeeper.GetState().RewardsRecord(ctx).
+		keepers.RewardsKeeper.GetState().RewardsRecord(ctx).
 			CreateRewardsRecord(
 				testRecord.RewardsAddr,
 				testRecord.Rewards,
@@ -79,7 +80,7 @@ func (s *KeeperTestSuite) CheckWithdrawResults(rewardsAddr sdk.AccAddress, recor
 	s.Assert().Equal(totalRewardsExpected.String(), accBalanceAfter.Sub(accBalanceBefore).String())
 
 	// Check records pruning
-	recordsState := s.chain.GetApp().RewardsKeeper.GetState().RewardsRecord(s.chain.GetContext())
+	recordsState := s.chain.GetApp().Keepers.RewardsKeeper.GetState().RewardsRecord(s.chain.GetContext())
 	for _, testRecord := range recordsUsed {
 		_, found := recordsState.GetRewardsRecord(testRecord.RecordID)
 		s.Assert().False(found, "recordID (%d): found", testRecord.RecordID)

--- a/x/rewards/keeper/flat_fee_test.go
+++ b/x/rewards/keeper/flat_fee_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *KeeperTestSuite) TestSetFlatFee() {
-	ctx, keeper := s.chain.GetContext(), s.chain.GetApp().RewardsKeeper
+	ctx, keeper := s.chain.GetContext(), s.chain.GetApp().Keepers.RewardsKeeper
 	contractAdminAcc := s.chain.GetAccount(0)
 	contractViewer := testutils.NewMockContractViewer()
 	keeper.SetContractInfoViewer(contractViewer)

--- a/x/rewards/keeper/genesis_test.go
+++ b/x/rewards/keeper/genesis_test.go
@@ -12,7 +12,7 @@ import (
 // TestGenesisImportExport check genesis import/export.
 // Test updates the initial state with new records and checks that they were merged.
 func (s *KeeperTestSuite) TestGenesisImportExport() {
-	ctx, keeper := s.chain.GetContext(), s.chain.GetApp().RewardsKeeper
+	ctx, keeper := s.chain.GetContext(), s.chain.GetApp().Keepers.RewardsKeeper
 
 	contractAddrs := e2eTesting.GenContractAddresses(2)
 	accAddrs, _ := e2eTesting.GenAccounts(2)

--- a/x/rewards/keeper/grpc_query_test.go
+++ b/x/rewards/keeper/grpc_query_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *KeeperTestSuite) TestGRPC_Params() {
-	ctx, k := s.chain.GetContext(), s.chain.GetApp().RewardsKeeper
+	ctx, k := s.chain.GetContext(), s.chain.GetApp().Keepers.RewardsKeeper
 	querySrvr := keeper.NewQueryServer(k)
 	params := rewardsTypes.Params{
 		InflationRewardsRatio: sdk.MustNewDecFromStr("0.1"),
@@ -38,7 +38,7 @@ func (s *KeeperTestSuite) TestGRPC_Params() {
 }
 
 func (s *KeeperTestSuite) TestGRPC_ContractMetadata() {
-	ctx, k := s.chain.GetContext(), s.chain.GetApp().RewardsKeeper
+	ctx, k := s.chain.GetContext(), s.chain.GetApp().Keepers.RewardsKeeper
 	querySrvr := keeper.NewQueryServer(k)
 	contractViewer := testutils.NewMockContractViewer()
 	k.SetContractInfoViewer(contractViewer)
@@ -80,7 +80,7 @@ func (s *KeeperTestSuite) TestGRPC_ContractMetadata() {
 }
 
 func (s *KeeperTestSuite) TestGRPC_BlockRewardsTracking() {
-	ctx, k := s.chain.GetContext(), s.chain.GetApp().RewardsKeeper
+	ctx, k := s.chain.GetContext(), s.chain.GetApp().Keepers.RewardsKeeper
 	querySrvr := keeper.NewQueryServer(k)
 
 	s.Run("err: empty request", func() {
@@ -98,7 +98,7 @@ func (s *KeeperTestSuite) TestGRPC_BlockRewardsTracking() {
 }
 
 func (s *KeeperTestSuite) TestGRPC_RewardsPool() {
-	ctx, k := s.chain.GetContext(), s.chain.GetApp().RewardsKeeper
+	ctx, k := s.chain.GetContext(), s.chain.GetApp().Keepers.RewardsKeeper
 	querySrvr := keeper.NewQueryServer(k)
 
 	s.Run("err: empty request", func() {
@@ -115,7 +115,7 @@ func (s *KeeperTestSuite) TestGRPC_RewardsPool() {
 }
 
 func (s *KeeperTestSuite) TestGRPC_EstimateTxFees() {
-	ctx, k := s.chain.GetContext(), s.chain.GetApp().RewardsKeeper
+	ctx, k := s.chain.GetContext(), s.chain.GetApp().Keepers.RewardsKeeper
 
 	querySrvr := keeper.NewQueryServer(k)
 
@@ -136,7 +136,7 @@ func (s *KeeperTestSuite) TestGRPC_EstimateTxFees() {
 
 	minConsFee := sdk.NewInt64Coin("stake", 100)
 	s.Run("ok: gets estimated tx fees (custom minconsfee set)", func() {
-		s.chain.GetApp().RewardsKeeper.GetState().MinConsensusFee(ctx).SetFee(sdk.NewDecCoinFromCoin(minConsFee))
+		s.chain.GetApp().Keepers.RewardsKeeper.GetState().MinConsensusFee(ctx).SetFee(sdk.NewDecCoinFromCoin(minConsFee))
 		res, err := querySrvr.EstimateTxFees(sdk.WrapSDKContext(ctx), &rewardsTypes.QueryEstimateTxFeesRequest{GasLimit: 1})
 		s.Require().NoError(err)
 		s.Require().NotNil(res)
@@ -199,7 +199,7 @@ func (s *KeeperTestSuite) TestGRPC_EstimateTxFees() {
 }
 
 func (s *KeeperTestSuite) TestGRPC_OutstandingRewards() {
-	ctx, k := s.chain.GetContext(), s.chain.GetApp().RewardsKeeper
+	ctx, k := s.chain.GetContext(), s.chain.GetApp().Keepers.RewardsKeeper
 
 	querySrvr := keeper.NewQueryServer(k)
 
@@ -227,7 +227,7 @@ func (s *KeeperTestSuite) TestGRPC_OutstandingRewards() {
 }
 
 func (s *KeeperTestSuite) TestGRPC_RewardsRecords() {
-	ctx, k := s.chain.GetContext(), s.chain.GetApp().RewardsKeeper
+	ctx, k := s.chain.GetContext(), s.chain.GetApp().Keepers.RewardsKeeper
 
 	querySrvr := keeper.NewQueryServer(k)
 
@@ -255,7 +255,7 @@ func (s *KeeperTestSuite) TestGRPC_RewardsRecords() {
 }
 
 func (s *KeeperTestSuite) TestGRPC_FlatFee() {
-	ctx, k := s.chain.GetContext(), s.chain.GetApp().RewardsKeeper
+	ctx, k := s.chain.GetContext(), s.chain.GetApp().Keepers.RewardsKeeper
 
 	querySrvr := keeper.NewQueryServer(k)
 

--- a/x/rewards/keeper/invariants_test.go
+++ b/x/rewards/keeper/invariants_test.go
@@ -140,15 +140,16 @@ func TestRewardsModuleAccountInvariant(t *testing.T) {
 			// Create chain
 			chain := e2eTesting.NewTestChain(t, 1)
 			ctx := chain.GetContext()
+			keepers := chain.GetApp().Keepers
 
 			// Remove all pool coins (not empty due to inflation rewards for previous blocks)
-			poolInitial := chain.GetApp().RewardsKeeper.UndistributedRewardsPool(ctx)
-			require.NoError(t, chain.GetApp().BankKeeper.SendCoinsFromModuleToModule(ctx, types.ContractRewardCollector, mintTypes.ModuleName, poolInitial))
+			poolInitial := keepers.RewardsKeeper.UndistributedRewardsPool(ctx)
+			require.NoError(t, keepers.BankKeeper.SendCoinsFromModuleToModule(ctx, types.ContractRewardCollector, mintTypes.ModuleName, poolInitial))
 
 			// Mint coins for module account
 			if tc.poolCoins != nil {
-				require.NoError(t, chain.GetApp().BankKeeper.MintCoins(ctx, mintTypes.ModuleName, tc.poolCoins))
-				require.NoError(t, chain.GetApp().BankKeeper.SendCoinsFromModuleToModule(ctx, mintTypes.ModuleName, types.ContractRewardCollector, tc.poolCoins))
+				require.NoError(t, keepers.BankKeeper.MintCoins(ctx, mintTypes.ModuleName, tc.poolCoins))
+				require.NoError(t, keepers.BankKeeper.SendCoinsFromModuleToModule(ctx, mintTypes.ModuleName, types.ContractRewardCollector, tc.poolCoins))
 			}
 
 			// Store rewards records
@@ -159,10 +160,10 @@ func TestRewardsModuleAccountInvariant(t *testing.T) {
 				}
 			}
 
-			chain.GetApp().RewardsKeeper.GetState().RewardsRecord(ctx).Import(recordLastID, tc.rewardsRecords)
+			keepers.RewardsKeeper.GetState().RewardsRecord(ctx).Import(recordLastID, tc.rewardsRecords)
 
 			// Check invariant
-			_, brokenReceived := keeper.ModuleAccountBalanceInvariant(chain.GetApp().RewardsKeeper)(ctx)
+			_, brokenReceived := keeper.ModuleAccountBalanceInvariant(keepers.RewardsKeeper)(ctx)
 			assert.Equal(t, tc.brokenExpected, brokenReceived)
 		})
 	}

--- a/x/rewards/keeper/metadata_test.go
+++ b/x/rewards/keeper/metadata_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *KeeperTestSuite) TestSetContractMetadata() {
-	ctx, keeper := s.chain.GetContext(), s.chain.GetApp().RewardsKeeper
+	ctx, keeper := s.chain.GetContext(), s.chain.GetApp().Keepers.RewardsKeeper
 	contractAdminAcc, otherAcc := s.chain.GetAccount(0), s.chain.GetAccount(1)
 	rewardAddr := sdk.AccAddress{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 

--- a/x/rewards/keeper/msg_server_test.go
+++ b/x/rewards/keeper/msg_server_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (s *KeeperTestSuite) TestMsgServer_SetContractMetadata() {
-	ctx, k := s.chain.GetContext(), s.chain.GetApp().RewardsKeeper
+	ctx, k := s.chain.GetContext(), s.chain.GetApp().Keepers.RewardsKeeper
 	contractAdminAcc, otherAcc := s.chain.GetAccount(0), s.chain.GetAccount(1)
 	contractViewer := testutils.NewMockContractViewer()
 	k.SetContractInfoViewer(contractViewer)
@@ -125,7 +125,7 @@ func (s *KeeperTestSuite) TestMsgServer_SetContractMetadata() {
 }
 
 func (s *KeeperTestSuite) TestMsgServer_WithdrawRewards() {
-	ctx, k := s.chain.GetContext(), s.chain.GetApp().RewardsKeeper
+	ctx, k := s.chain.GetContext(), s.chain.GetApp().Keepers.RewardsKeeper
 	acc := s.chain.GetAccount(0).Address
 
 	server := keeper.NewMsgServer(k)
@@ -229,7 +229,7 @@ func (s *KeeperTestSuite) TestMsgServer_WithdrawRewards() {
 }
 
 func (s *KeeperTestSuite) TestMsgServer_SetFlatFee() {
-	ctx, k := s.chain.GetContext(), s.chain.GetApp().RewardsKeeper
+	ctx, k := s.chain.GetContext(), s.chain.GetApp().Keepers.RewardsKeeper
 	contractAdminAcc, otherAcc := s.chain.GetAccount(0), s.chain.GetAccount(1)
 	contractViewer := testutils.NewMockContractViewer()
 	k.SetContractInfoViewer(contractViewer)

--- a/x/rewards/keeper/state_flatfee_test.go
+++ b/x/rewards/keeper/state_flatfee_test.go
@@ -10,7 +10,7 @@ import (
 // TestFlatFeeImportExport check flat fees import/export.
 // Test updates the initial state with new records and checks that they were merged.
 func (s *KeeperTestSuite) TestFlatFeeImportExport() {
-	ctx, keeper := s.chain.GetContext(), s.chain.GetApp().RewardsKeeper
+	ctx, keeper := s.chain.GetContext(), s.chain.GetApp().Keepers.RewardsKeeper
 	contractAddrs := e2eTesting.GenContractAddresses(2)
 
 	newFlatFees := []rewardsTypes.FlatFee{

--- a/x/rewards/keeper/state_test.go
+++ b/x/rewards/keeper/state_test.go
@@ -27,7 +27,7 @@ func (s *KeeperTestSuite) TestStates() {
 	}
 
 	chain := s.chain
-	ctx, keeper := chain.GetContext(), chain.GetApp().RewardsKeeper
+	ctx, keeper := chain.GetContext(), chain.GetApp().Keepers.RewardsKeeper
 	metaState := keeper.GetState().ContractMetadataState(ctx)
 	blockState := keeper.GetState().BlockRewardsState(ctx)
 	txState := keeper.GetState().TxRewardsState(ctx)

--- a/x/rewards/keeper/withdraw_test.go
+++ b/x/rewards/keeper/withdraw_test.go
@@ -8,7 +8,7 @@ import (
 
 // TestWithdrawRewardsByLimit tests the withdraw operation using record limit mode.
 func (s *KeeperTestSuite) TestWithdrawRewardsByLimit() {
-	keeper := s.chain.GetApp().RewardsKeeper
+	keeper := s.chain.GetApp().Keepers.RewardsKeeper
 	accAddr := s.chain.GetAccount(0).Address
 
 	testData := []withdrawTestRecordData{
@@ -73,7 +73,7 @@ func (s *KeeperTestSuite) TestWithdrawRewardsByLimit() {
 
 // TestWithdrawRewardsByIDs tests the withdraw operation using record IDs mode.
 func (s *KeeperTestSuite) TestWithdrawRewardsByIDs() {
-	keeper := s.chain.GetApp().RewardsKeeper
+	keeper := s.chain.GetApp().Keepers.RewardsKeeper
 	accAddr1, accAddr2 := s.chain.GetAccount(0).Address, s.chain.GetAccount(1).Address
 
 	testData := []withdrawTestRecordData{

--- a/x/rewards/mintbankkeeper/keeper_test.go
+++ b/x/rewards/mintbankkeeper/keeper_test.go
@@ -124,6 +124,7 @@ func TestMintBankKeeper(t *testing.T) {
 				e2eTesting.WithBlockGasLimit(tc.blockMaxGas),
 			)
 			ctx := chain.GetContext()
+			keepers := chain.GetApp().Keepers
 
 			// Fetch initial balances
 			srcBalanceBefore := chain.GetModuleBalance(tc.srcModule)
@@ -134,14 +135,14 @@ func TestMintBankKeeper(t *testing.T) {
 			transferCoins, err := sdk.ParseCoinsNormalized(tc.transferCoins)
 			require.NoError(t, err)
 
-			require.NoError(t, chain.GetApp().MintKeeper.MintCoins(ctx, transferCoins))
-			require.NoError(t, chain.GetApp().BankKeeper.SendCoinsFromModuleToModule(ctx, mintTypes.ModuleName, tc.srcModule, transferCoins))
+			require.NoError(t, keepers.MintKeeper.MintCoins(ctx, transferCoins))
+			require.NoError(t, keepers.BankKeeper.SendCoinsFromModuleToModule(ctx, mintTypes.ModuleName, tc.srcModule, transferCoins))
 
 			// Remove rewards records which is created automagically
-			chain.GetApp().RewardsKeeper.GetState().DeleteBlockRewardsCascade(ctx, ctx.BlockHeight())
+			keepers.RewardsKeeper.GetState().DeleteBlockRewardsCascade(ctx, ctx.BlockHeight())
 
 			// Transfer via keeper
-			k := mintbankkeeper.NewKeeper(chain.GetApp().BankKeeper, chain.GetApp().RewardsKeeper)
+			k := mintbankkeeper.NewKeeper(keepers.BankKeeper, keepers.RewardsKeeper)
 			err = k.SendCoinsFromModuleToModule(ctx, tc.srcModule, tc.dstModule, transferCoins)
 			if tc.errExpected {
 				assert.Error(t, err)
@@ -168,7 +169,7 @@ func TestMintBankKeeper(t *testing.T) {
 			assert.Equal(t, rewardsDiffExpected.String(), rewardsBalanceDiffReceived.String())
 
 			// Check rewards record
-			rewardsRecordReceived, found := chain.GetApp().RewardsKeeper.GetState().BlockRewardsState(ctx).GetBlockRewards(ctx.BlockHeight())
+			rewardsRecordReceived, found := keepers.RewardsKeeper.GetState().BlockRewardsState(ctx).GetBlockRewards(ctx.BlockHeight())
 			if !tc.rewardRecordExpected {
 				require.False(t, found)
 				return
@@ -185,7 +186,7 @@ func TestMintBankKeeper(t *testing.T) {
 			assert.Equal(t, maxGasExpected, rewardsRecordReceived.MaxGas)
 
 			// Check minimum consensus fee record
-			minConsFeeReceived, minConfFeeFound := chain.GetApp().RewardsKeeper.GetState().MinConsensusFee(ctx).GetFee()
+			minConsFeeReceived, minConfFeeFound := keepers.RewardsKeeper.GetState().MinConsensusFee(ctx).GetFee()
 			if maxGasExpected == 0 || rewardsDiffExpected.IsZero() {
 				assert.False(t, minConfFeeFound)
 			} else {
@@ -195,7 +196,7 @@ func TestMintBankKeeper(t *testing.T) {
 					Denom: sdk.DefaultBondDenom,
 					Amount: rewardsDiffExpected[0].Amount.ToDec().Quo(
 						pkg.NewDecFromUint64(maxGasExpected).Mul(
-							chain.GetApp().RewardsKeeper.TxFeeRebateRatio(ctx).Sub(sdk.OneDec()),
+							keepers.RewardsKeeper.TxFeeRebateRatio(ctx).Sub(sdk.OneDec()),
 						),
 					).Neg(),
 				}

--- a/x/tracking/ante/tracking_test.go
+++ b/x/tracking/ante/tracking_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestTrackingAnteHandler(t *testing.T) {
 	chain := e2eTesting.NewTestChain(t, 1)
-	ctx, keeper := chain.GetContext(), chain.GetApp().TrackingKeeper
+	ctx, keeper := chain.GetContext(), chain.GetApp().Keepers.TrackingKeeper
 
 	anteHandler := ante.NewTxGasTrackingDecorator(keeper)
 	for i := uint64(1); i < 10; i++ {

--- a/x/tracking/keeper/genesis_test.go
+++ b/x/tracking/keeper/genesis_test.go
@@ -9,7 +9,7 @@ import (
 // TestGenesisImportExport check genesis import/export.
 // Test updates the initial state with new txs and checks that they were merged.
 func (s *KeeperTestSuite) TestGenesisImportExport() {
-	ctx, keeper := s.chain.GetContext(), s.chain.GetApp().TrackingKeeper
+	ctx, keeper := s.chain.GetContext(), s.chain.GetApp().Keepers.TrackingKeeper
 
 	contractAddrs := e2eTesting.GenContractAddresses(2)
 

--- a/x/tracking/keeper/state_test.go
+++ b/x/tracking/keeper/state_test.go
@@ -18,7 +18,7 @@ func (s *KeeperTestSuite) TestStates() {
 	}
 
 	chain := s.chain
-	ctx, keeper := chain.GetContext(), chain.GetApp().TrackingKeeper
+	ctx, keeper := chain.GetContext(), chain.GetApp().Keepers.TrackingKeeper
 
 	// Fixtures
 	startBlock := ctx.BlockHeight()


### PR DESCRIPTION
Closes: #456 

- Create a new struct which holds all the archway app keepers called `ArchwayKeepers`
- Pass in this struct to the upgrade handlers 