### PR TITLE
feat: bumping archway wasmd to v0.42.0

### DIFF
--- a/Dockerfile.deprecated
+++ b/Dockerfile.deprecated
@@ -2,8 +2,8 @@ FROM golang:1.19.5-alpine3.17 AS go-builder
 # arch can be either x86_64 for amd64 or aarch64 for arm
 ARG arch=x86_64
 ARG libwasmvm_version=v1.3.0
-ARG libwasmvm_aarch64_sha=b1610f9c8ad8bdebf5b8f819f71d238466f83521c74a2deb799078932e862722
-ARG libwasmvm_amd64_sha=b4aad4480f9b4c46635b4943beedbb72c929eab1d1b9467fe3b43e6dbf617e32
+ARG libwasmvm_aarch64_sha=2a72c7062e3c791792b3dab781c815c9a76083a7997ce6f9f2799aaf577f3c25
+ARG libwasmvm_amd64_sha=8ea2e3b5fae83e671da2bb51115adc88591045953f509955ec38dc02ea5a7b94
 
 # this comes from standard alpine nightly file
 #  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile

--- a/app/app.go
+++ b/app/app.go
@@ -524,7 +524,7 @@ func NewArchwayApp(
 
 	// The last arguments can contain custom message handlers, and custom query handlers,
 	// if we want to allow any custom callbacks
-	supportedFeatures := "iterator,staking,stargate,cosmwasm_1_1,cosmwasm_1_2,cosmwasm_1_3"
+	supportedFeatures := "iterator,staking,stargate,cosmwasm_1_1,cosmwasm_1_2,cosmwasm_1_3,cosmwasm_1_4"
 
 	wasmer, err := cosmwasm.NewVM(filepath.Join(wasmDir, "wasm"), supportedFeatures, 32, wasmConfig.ContractDebugMode, wasmConfig.MemoryCacheSize)
 	if err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -508,7 +508,7 @@ func NewArchwayApp(
 	)
 	app.Keepers.EvidenceKeeper = *evidenceKeeper
 
-	defaultGasRegister := wasmdKeeper.NewDefaultWasmGasRegister()
+	defaultGasRegister := wasmdTypes.NewDefaultWasmGasRegister()
 
 	app.Keepers.TrackingKeeper = trackingKeeper.NewKeeper(
 		appCodec,

--- a/go.mod
+++ b/go.mod
@@ -6,14 +6,14 @@ require (
 	cosmossdk.io/api v0.3.1
 	cosmossdk.io/errors v1.0.0
 	github.com/CosmWasm/cosmwasm-go v0.5.1-0.20220822092235-974247a04ac7
-	github.com/CosmWasm/wasmd v0.41.0
-	github.com/CosmWasm/wasmvm v1.3.0
+	github.com/CosmWasm/wasmd v0.42.0
+	github.com/CosmWasm/wasmvm v1.4.0
 	github.com/archway-network/voter v0.0.0-00010101000000-000000000000
 	github.com/cometbft/cometbft v0.37.2
 	github.com/cometbft/cometbft-db v0.8.0
 	github.com/cosmos/cosmos-sdk v0.47.5
 	github.com/cosmos/gogoproto v1.4.10
-	github.com/cosmos/ibc-go/v7 v7.2.0
+	github.com/cosmos/ibc-go/v7 v7.3.0
 	github.com/dvsekhvalnov/jose2go v1.5.0
 	github.com/golang/protobuf v1.5.3
 	github.com/gorilla/mux v1.8.0
@@ -68,7 +68,7 @@ require (
 	github.com/cosmos/cosmos-proto v1.0.0-beta.2 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
-	github.com/cosmos/iavl v0.20.0 // indirect
+	github.com/cosmos/iavl v0.20.1 // indirect
 	github.com/cosmos/ics23/go v0.10.0 // indirect
 	github.com/cosmos/ledger-cosmos-go v0.12.2 // indirect
 	github.com/cosmos/rosetta-sdk-go v0.10.0 // indirect
@@ -184,7 +184,7 @@ require (
 	pgregory.net/rapid v0.5.5 // indirect
 )
 
-replace github.com/CosmWasm/wasmd => github.com/archway-network/archway-wasmd v0.41.0-archway
+replace github.com/CosmWasm/wasmd => github.com/archway-network/archway-wasmd v0.42.0-archway
 
 replace github.com/archway-network/voter => ./contracts/go/voter
 

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/CosmWasm/cosmwasm-go v0.5.1-0.20220822092235-974247a04ac7 h1:aENjurRl
 github.com/CosmWasm/cosmwasm-go v0.5.1-0.20220822092235-974247a04ac7/go.mod h1:qCTzr8cQYwoYdA9AT4azEVbiYGjULS1nrUgw6YScXks=
 github.com/CosmWasm/tinyjson v0.9.0 h1:sPjgikATp5W0vD/v/Qz99uQ6G/lh/SuK0Wfskqua4Co=
 github.com/CosmWasm/tinyjson v0.9.0/go.mod h1:5+7QnSKrkIWnpIdhUT2t2EYzXnII3/3MlM0oDsBSbc8=
-github.com/CosmWasm/wasmvm v1.3.0 h1:x12X4bKlUPS7TT9QQP45+fJo2sp30GEbiSSgb9jsec8=
-github.com/CosmWasm/wasmvm v1.3.0/go.mod h1:vW/E3h8j9xBQs9bCoijDuawKo9kCtxOaS8N8J7KFtkc=
+github.com/CosmWasm/wasmvm v1.4.0 h1:84I3MlvvzcOo2z+ed0ztPi7eeDNk6/sYuK76uyXP1nI=
+github.com/CosmWasm/wasmvm v1.4.0/go.mod h1:vW/E3h8j9xBQs9bCoijDuawKo9kCtxOaS8N8J7KFtkc=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
@@ -257,8 +257,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/archway-network/archway-wasmd v0.41.0-archway h1:bK7grwyfUT4gNXBAbxoQ3TdU3Cm6lApdfAg1X05n8dE=
-github.com/archway-network/archway-wasmd v0.41.0-archway/go.mod h1:0Sds1q2IsPaTN1gHa3BNOYcUFgtGvxH7CXEXPgoihns=
+github.com/archway-network/archway-wasmd v0.42.0-archway h1:tDlPUIYh70l6jlt1tY5FD8+mjetju8GIdG1bv7q9C40=
+github.com/archway-network/archway-wasmd v0.42.0-archway/go.mod h1:DiEyBjHxzkEENYqQhHyka+r4HfR72stSPUtGv+Yh/UU=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -401,10 +401,10 @@ github.com/cosmos/gogoproto v1.4.2/go.mod h1:cLxOsn1ljAHSV527CHOtaIP91kK6cCrZETR
 github.com/cosmos/gogoproto v1.4.10 h1:QH/yT8X+c0F4ZDacDv3z+xE3WU1P1Z3wQoLMBRJoKuI=
 github.com/cosmos/gogoproto v1.4.10/go.mod h1:3aAZzeRWpAwr+SS/LLkICX2/kDFyaYVzckBDzygIxek=
 github.com/cosmos/gorocksdb v1.2.0 h1:d0l3jJG8M4hBouIZq0mDUHZ+zjOx044J3nGRskwTb4Y=
-github.com/cosmos/iavl v0.20.0 h1:fTVznVlepH0KK8NyKq8w+U7c2L6jofa27aFX6YGlm38=
-github.com/cosmos/iavl v0.20.0/go.mod h1:WO7FyvaZJoH65+HFOsDir7xU9FWk2w9cHXNW1XHcl7A=
-github.com/cosmos/ibc-go/v7 v7.2.0 h1:dx0DLUl7rxdyZ8NiT6UsrbzKOJx/w7s+BOaewFRH6cg=
-github.com/cosmos/ibc-go/v7 v7.2.0/go.mod h1:OOcjKIRku/j1Xs1RgKK0yvKRrJ5iFuZYMetR1n3yMlc=
+github.com/cosmos/iavl v0.20.1 h1:rM1kqeG3/HBT85vsZdoSNsehciqUQPWrR4BYmqE2+zg=
+github.com/cosmos/iavl v0.20.1/go.mod h1:WO7FyvaZJoH65+HFOsDir7xU9FWk2w9cHXNW1XHcl7A=
+github.com/cosmos/ibc-go/v7 v7.3.0 h1:QtGeVMi/3JeLWuvEuC60sBHpAF40Oenx/y+bP8+wRRw=
+github.com/cosmos/ibc-go/v7 v7.3.0/go.mod h1:mUmaHFXpXrEdcxfdXyau+utZf14pGKVUiXwYftRZZfQ=
 github.com/cosmos/ics23/go v0.10.0 h1:iXqLLgp2Lp+EdpIuwXTYIQU+AiHj9mOC2X9ab++bZDM=
 github.com/cosmos/ics23/go v0.10.0/go.mod h1:ZfJSmng/TBNTBkFemHHHj5YY7VAU/MBU980F4VU1NG0=
 github.com/cosmos/ledger-cosmos-go v0.12.2 h1:/XYaBlE2BJxtvpkHiBm97gFGSGmYGKunKyF3nNqAXZA=

--- a/x/tracking/keeper/keeper.go
+++ b/x/tracking/keeper/keeper.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	wasmKeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
@@ -12,14 +12,14 @@ import (
 
 // Keeper provides module state operations.
 type Keeper struct {
-	WasmGasRegister wasmKeeper.GasRegister
+	WasmGasRegister wasmtypes.GasRegister
 
 	cdc   codec.Codec
 	state State
 }
 
 // NewKeeper creates a new Keeper instance.
-func NewKeeper(cdc codec.Codec, key storetypes.StoreKey, gasRegister wasmKeeper.GasRegister) Keeper {
+func NewKeeper(cdc codec.Codec, key storetypes.StoreKey, gasRegister wasmtypes.GasRegister) Keeper {
 	return Keeper{
 		cdc:             cdc,
 		WasmGasRegister: gasRegister,


### PR DESCRIPTION
- Bumping the wasmd fork to `v0.42.0-archway` https://github.com/archway-network/archway-wasmd/pull/8
- Adding [Cosmwasm_1_4](https://github.com/CosmWasm/cosmwasm/blob/f11b456d46073d0324d9e39ed617f7fcfdbe1b06/docs/CAPABILITIES-BUILT-IN.md) capabilities 
- Updated Dockerfile with updating wasmvm version. [checksum src](https://github.com/CosmWasm/wasmvm/releases)