### PR TITLE
chore: remove unused titus deployment from the pipeline

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,32 +38,3 @@ jobs:
           env:
             GORELEASER_SKIP_VALIDATE: true
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  deploy-titus:
-    runs-on: ubuntu-latest
-
-    needs:
-      - release-dev
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Set short git commit SHA
-        id: vars
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
-      - name: Inject version and secrets to titus-1.yaml
-        run: |
-          sed -i -e "s|NODE_VERSION|${{ steps.vars.outputs.sha_short }}|g" ci/titus-1.yaml
-          sed -i -e "s|TITUS_1_ACCOUNT_MNEMONIC_B64|${{ secrets.TITUS_1_ACCOUNT_MNEMONIC_B64 }}|g" ci/titus-1.yaml
-          sed -i -e "s|TITUS_1_FAUCET_ACCOUNT_MNEMONIC_B64|${{ secrets.TITUS_1_FAUCET_ACCOUNT_MNEMONIC_B64 }}|g" ci/titus-1.yaml
-          sed -i -e "s|TITUS_1_PRIV_VALIDATOR_KEY_B64|${{ secrets.TITUS_1_PRIV_VALIDATOR_KEY_B64 }}|g" ci/titus-1.yaml
-
-      - name: Deploy Chain
-        uses: steebchen/kubectl@v2.0.0
-        with:
-          config: ${{ secrets.GKE_SHARED_NONPROD_GH_ACTIONS_BOT_KUBECONFIG }}
-          command: apply -n testnets -f ci/titus-1.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Contains all the PRs that improved the code without changing the behaviours.
 
 ## [Unreleased]
 
-### Added 
+### Added
 
 - [#431](https://github.com/archway-network/archway/pull/431) - Added gh workflow to run IBC conformance tests on PRs
 
@@ -46,6 +46,7 @@ Contains all the PRs that improved the code without changing the behaviours.
 ### Deprecated
 
 - [#439](https://github.com/archway-network/archway/pull/439) - Renaming `debug` image to `dev`
+- [#461](https://github.com/archway-network/archway/pull/461) - Remove titus network deployment
 
 ### Removed
 


### PR DESCRIPTION
Titus network is not used anymore so the deployment can be removed.