### PR TITLE
fix: updating logic for how we deal with infiniteGasMeter

### DIFF
--- a/x/rewards/keeper/min_cons_fee.go
+++ b/x/rewards/keeper/min_cons_fee.go
@@ -1,6 +1,9 @@
 package keeper
 
 import (
+	"reflect"
+	"strings"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/archway-network/archway/pkg"
@@ -14,11 +17,15 @@ func (k Keeper) UpdateMinConsensusFee(ctx sdk.Context, inflationRewards sdk.Coin
 		k.Logger(ctx).Info("Minimum consensus fee update skipped: inflation rewards are zero")
 		return
 	}
-
 	inflationRewardsAmt := sdk.NewDecFromInt(inflationRewards.Amount)
 
-	blockGasLimit := pkg.NewDecFromUint64(ctx.BlockGasMeter().Limit())
-	if blockGasLimit.IsZero() {
+	blockGasLimit := ctx.BlockGasMeter().Limit()
+	if strings.Contains(reflect.TypeOf(ctx.BlockGasMeter()).String(), "infiniteGasMeter") { // Because thisss https://github.com/cosmos/cosmos-sdk/pull/9651
+		blockGasLimit = 0
+	}
+
+	blockGasLimitAsDec := pkg.NewDecFromUint64(blockGasLimit)
+	if blockGasLimitAsDec.IsZero() {
 		k.Logger(ctx).Info("Minimum consensus fee update skipped: block gas limit is not set")
 		return
 	}
@@ -26,7 +33,7 @@ func (k Keeper) UpdateMinConsensusFee(ctx sdk.Context, inflationRewards sdk.Coin
 	txFeeRebateRatio := k.TxFeeRebateRatio(ctx)
 
 	// Calculate
-	feeAmt := calculateMinConsensusFeeAmt(inflationRewardsAmt, blockGasLimit, txFeeRebateRatio)
+	feeAmt := calculateMinConsensusFeeAmt(inflationRewardsAmt, blockGasLimitAsDec, txFeeRebateRatio)
 	if feeAmt.IsZero() || feeAmt.IsNegative() {
 		k.Logger(ctx).Info("Minimum consensus fee update skipped: calculated amount is zero or bellow zero")
 		return

--- a/x/rewards/keeper/tracking.go
+++ b/x/rewards/keeper/tracking.go
@@ -1,6 +1,9 @@
 package keeper
 
 import (
+	"reflect"
+	"strings"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -18,9 +21,14 @@ func (k Keeper) TrackFeeRebatesRewards(ctx sdk.Context, rewards sdk.Coins) {
 
 // TrackInflationRewards creates a new inflation reward record for the current block.
 func (k Keeper) TrackInflationRewards(ctx sdk.Context, rewards sdk.Coin) {
+	blockGasLimit := ctx.BlockGasMeter().Limit()
+	if strings.Contains(reflect.TypeOf(ctx.BlockGasMeter()).String(), "infiniteGasMeter") { // Because thisss https://github.com/cosmos/cosmos-sdk/pull/9651
+		blockGasLimit = 0
+	}
+
 	k.state.BlockRewardsState(ctx).CreateBlockRewards(
 		ctx.BlockHeight(),
 		rewards,
-		ctx.BlockGasMeter().Limit(),
+		blockGasLimit,
 	)
 }

--- a/x/rewards/keeper/tracking.go
+++ b/x/rewards/keeper/tracking.go
@@ -1,8 +1,7 @@
 package keeper
 
 import (
-	"reflect"
-	"strings"
+	"math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -22,7 +21,7 @@ func (k Keeper) TrackFeeRebatesRewards(ctx sdk.Context, rewards sdk.Coins) {
 // TrackInflationRewards creates a new inflation reward record for the current block.
 func (k Keeper) TrackInflationRewards(ctx sdk.Context, rewards sdk.Coin) {
 	blockGasLimit := ctx.BlockGasMeter().Limit()
-	if strings.Contains(reflect.TypeOf(ctx.BlockGasMeter()).String(), "infiniteGasMeter") { // Because thisss https://github.com/cosmos/cosmos-sdk/pull/9651
+	if ctx.BlockGasMeter().Limit() == math.MaxUint64 { // Because thisss https://github.com/cosmos/cosmos-sdk/pull/9651
 		blockGasLimit = 0
 	}
 


### PR DESCRIPTION
Fixing our logic for
- Updating min-consensus-fee
- Tracking inflationary rewards

because it was rugged by sdk 47 changes to the infiniteGasMeter https://github.com/cosmos/cosmos-sdk/pull/9651

Before (sdk 45)  && After (sdk 47)
<img alt="image" src="https://github.com/archway-network/archway/assets/9302666/5a5c6892-7168-4069-9fd4-0441499c61a1">
