### PR TITLE
tests : fixing ibc conformance test

### DIFF
--- a/interchaintest/chain_upgrade_test.go
+++ b/interchaintest/chain_upgrade_test.go
@@ -98,6 +98,7 @@ func startChain(t *testing.T, startingVersion string) (*cosmos.CosmosChain, *cli
 	numOfVals := 1
 	archwayChainSpec := GetArchwaySpec(initialVersion, numOfVals)
 	archwayChainSpec.UsingNewGenesisCommand = false
+	archwayChainSpec.ChainConfig.ModifyGenesis = cosmos.ModifyGenesis(getTestGenesis())
 	cf := interchaintest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*interchaintest.ChainSpec{
 		archwayChainSpec,
 	})

--- a/interchaintest/setup.go
+++ b/interchaintest/setup.go
@@ -56,7 +56,6 @@ func getDefaultChainConfig() ibc.ChainConfig {
 		NoHostMount:            false,
 		SkipGenTx:              false,
 		PreGenesis:             nil,
-		ModifyGenesis:          cosmos.ModifyGenesis(getTestGenesis()),
 		UsingNewGenesisCommand: true,
 		ModifyGenesisAmounts: func() (types.Coin, types.Coin) {
 			genesisAmount := types.Coin{


### PR DESCRIPTION
The custom gov param change only needed for the chain upgrade tests. was messing with ibc tests.
moved the customization to apply just to chain upgrade test.