### PR TITLE
feat: bumping archway wasmd to v0.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Contains all the PRs that improved the code without changing the behaviours.
 - [#445](https://github.com/archway-network/archway/pull/445) - Adding Archway logo and version number to upgrade logs
 - [#459](https://github.com/archway-network/archway/pull/459) - Add missing ADR references to docs index
 - [#442](https://github.com/archway-network/archway/pull/442) - Upgrade Cosmos-sdk from v0.45.16 to v0.47.5 and all the other things it depends on
+- [#470](https://github.com/archway-network/archway/pull/470) - Bumping x/wasmd to v0.43.0
 
 ### Changed
 

--- a/Dockerfile.deprecated
+++ b/Dockerfile.deprecated
@@ -1,9 +1,9 @@
 FROM golang:1.19.5-alpine3.17 AS go-builder
 # arch can be either x86_64 for amd64 or aarch64 for arm
 ARG arch=x86_64
-ARG libwasmvm_version=v1.3.0
-ARG libwasmvm_aarch64_sha=2a72c7062e3c791792b3dab781c815c9a76083a7997ce6f9f2799aaf577f3c25
-ARG libwasmvm_amd64_sha=8ea2e3b5fae83e671da2bb51115adc88591045953f509955ec38dc02ea5a7b94
+ARG libwasmvm_version=v1.4.1
+ARG libwasmvm_aarch64_sha=a8259ba852f1b68f2a5f8eb666a9c7f1680196562022f71bb361be1472a83cfd
+ARG libwasmvm_amd64_sha=324c1073cb988478d644861783ed5a7de21cfd090976ccc6b1de0559098fbbad
 
 # this comes from standard alpine nightly file
 #  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile

--- a/app/app.go
+++ b/app/app.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/archway-network/archway/app/keepers"
 	"github.com/archway-network/archway/x/genmsg"
@@ -148,32 +147,7 @@ const appName = "Archway"
 var (
 	NodeDir      = ".archway"
 	Bech32Prefix = "archway"
-
-	// ProposalsEnabled If EnabledSpecificProposals is "", and this is "true", then enable all x/wasm proposals.
-	// If EnabledSpecificProposals is "", and this is not "true", then disable all x/wasm proposals.
-	ProposalsEnabled = "false"
-	// EnableSpecificProposals If set to non-empty string it must be comma-separated list of values that are all a subset
-	// of "EnableAllProposals" (takes precedence over ProposalsEnabled)
-	// https://github.com/CosmWasm/wasmd/blob/02a54d33ff2c064f3539ae12d75d027d9c665f05/x/wasm/internal/types/proposal.go#L28-L34
-	EnableSpecificProposals = "SudoContract"
 )
-
-// GetEnabledProposals parses the ProposalsEnabled / EnableSpecificProposals values to
-// produce a list of enabled proposals to pass into archwayd app.
-func GetEnabledProposals() []wasmdTypes.ProposalType {
-	if EnableSpecificProposals == "" {
-		if ProposalsEnabled == "true" {
-			return wasmdTypes.EnableAllProposals
-		}
-		return wasmdTypes.DisableAllProposals
-	}
-	chunks := strings.Split(EnableSpecificProposals, ",")
-	proposals, err := wasmdTypes.ConvertToProposals(chunks)
-	if err != nil {
-		panic(err)
-	}
-	return proposals
-}
 
 // These constants are derived from the above variables.
 // These are the ones we will want to use in the code, based on
@@ -303,7 +277,6 @@ func NewArchwayApp(
 	homePath string,
 	invCheckPeriod uint,
 	encodingConfig archwayappparams.EncodingConfig,
-	enabledProposals []wasmdTypes.ProposalType,
 	appOpts servertypes.AppOptions,
 	wasmOpts []wasmdKeeper.Option,
 	baseAppOptions ...func(*baseapp.BaseApp),

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -20,13 +20,11 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
-	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 )
 
 var emptyWasmOpts []wasmkeeper.Option = nil
@@ -36,7 +34,7 @@ func TestArchwaydExport(t *testing.T) {
 	logger := log.NewNopLogger()
 	encoding := MakeEncodingConfig()
 	gapp := NewArchwayApp(logger, db, nil, true, map[int64]bool{}, DefaultNodeHome, 0, encoding,
-		wasmtypes.EnableAllProposals, EmptyBaseAppOptions{}, emptyWasmOpts)
+		EmptyBaseAppOptions{}, emptyWasmOpts)
 
 	privValidator := mock.NewPV()
 	pubKey, err := privValidator.GetPubKey()
@@ -77,7 +75,7 @@ func TestArchwaydExport(t *testing.T) {
 // ensure that blocked addresses are properly set in bank keeper
 func TestBlockedAddrs(t *testing.T) {
 	db := db.NewMemDB()
-	gapp := NewArchwayApp(log.NewTMLogger(log.NewSyncWriter(os.Stdout)), db, nil, true, map[int64]bool{}, DefaultNodeHome, 0, MakeEncodingConfig(), wasmtypes.EnableAllProposals, EmptyBaseAppOptions{}, emptyWasmOpts)
+	gapp := NewArchwayApp(log.NewTMLogger(log.NewSyncWriter(os.Stdout)), db, nil, true, map[int64]bool{}, DefaultNodeHome, 0, MakeEncodingConfig(), EmptyBaseAppOptions{}, emptyWasmOpts)
 
 	for acc := range BlockedAddresses() {
 		var addr sdk.AccAddress
@@ -98,37 +96,6 @@ func TestBlockedAddrs(t *testing.T) {
 func TestGetMaccPerms(t *testing.T) {
 	dup := GetMaccPerms()
 	require.Equal(t, maccPerms, dup, "duplicated module account permissions differed from actual module account permissions")
-}
-
-func TestGetEnabledProposals(t *testing.T) {
-	cases := map[string]struct {
-		proposalsEnabled string
-		specificEnabled  string
-		expected         []wasmtypes.ProposalType
-	}{
-		"all disabled": {
-			proposalsEnabled: "false",
-			expected:         wasmtypes.DisableAllProposals,
-		},
-		"all enabled": {
-			proposalsEnabled: "true",
-			expected:         wasmtypes.EnableAllProposals,
-		},
-		"some enabled": {
-			proposalsEnabled: "okay",
-			specificEnabled:  "StoreCode,InstantiateContract",
-			expected:         []wasmtypes.ProposalType{wasmtypes.ProposalTypeStoreCode, wasmtypes.ProposalTypeInstantiateContract},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			ProposalsEnabled = tc.proposalsEnabled
-			EnableSpecificProposals = tc.specificEnabled
-			proposals := GetEnabledProposals()
-			assert.Equal(t, tc.expected, proposals)
-		})
-	}
 }
 
 func genesisStateWithValSet(t *testing.T,

--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -112,7 +112,7 @@ func TestAppImportExport(t *testing.T) {
 	}()
 
 	encConf := MakeEncodingConfig()
-	app := NewArchwayApp(logger, db, nil, true, map[int64]bool{}, dir, simcli.FlagPeriodValue, encConf, wasmtypes.EnableAllProposals, EmptyBaseAppOptions{}, nil, fauxMerkleModeOpt)
+	app := NewArchwayApp(logger, db, nil, true, map[int64]bool{}, dir, simcli.FlagPeriodValue, encConf, EmptyBaseAppOptions{}, nil, fauxMerkleModeOpt)
 	require.Equal(t, appName, app.Name())
 
 	// Run randomized simulation
@@ -151,7 +151,7 @@ func TestAppImportExport(t *testing.T) {
 		newDB.Close()
 		require.NoError(t, os.RemoveAll(newDir))
 	}()
-	newApp := NewArchwayApp(logger, newDB, nil, true, map[int64]bool{}, newDir, simcli.FlagPeriodValue, encConf, wasmtypes.EnableAllProposals, EmptyBaseAppOptions{}, nil, fauxMerkleModeOpt)
+	newApp := NewArchwayApp(logger, newDB, nil, true, map[int64]bool{}, newDir, simcli.FlagPeriodValue, encConf, EmptyBaseAppOptions{}, nil, fauxMerkleModeOpt)
 	require.Equal(t, appName, newApp.Name())
 
 	var genesisState GenesisState
@@ -218,7 +218,7 @@ func TestFullAppSimulation(t *testing.T) {
 	}()
 	encConf := MakeEncodingConfig()
 	app := NewArchwayApp(logger, db, nil, true, map[int64]bool{}, DefaultNodeHome, simcli.FlagPeriodValue,
-		encConf, wasmtypes.EnableAllProposals, sims.EmptyAppOptions{}, nil, fauxMerkleModeOpt)
+		encConf, sims.EmptyAppOptions{}, nil, fauxMerkleModeOpt)
 	require.Equal(t, "ArchwayApp", app.Name())
 
 	// run randomized simulation

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
-	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 
 	errorsmod "cosmossdk.io/errors"
 	math "cosmossdk.io/math"
@@ -59,7 +58,7 @@ var DefaultConsensusParams = &tmproto.ConsensusParams{
 
 func setup(withGenesis bool, invCheckPeriod uint, opts ...wasmkeeper.Option) (*ArchwayApp, GenesisState) {
 	db := dbm.NewMemDB()
-	app := NewArchwayApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, DefaultNodeHome, invCheckPeriod, MakeEncodingConfig(), wasmtypes.EnableAllProposals, EmptyBaseAppOptions{}, opts)
+	app := NewArchwayApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, DefaultNodeHome, invCheckPeriod, MakeEncodingConfig(), EmptyBaseAppOptions{}, opts)
 	if withGenesis {
 		return app, NewDefaultGenesisState(app.AppCodec())
 	}

--- a/cmd/archwayd/root.go
+++ b/cmd/archwayd/root.go
@@ -269,7 +269,6 @@ func (ac appCreator) newApp(
 		cast.ToString(appOpts.Get(flags.FlagHome)),
 		cast.ToUint(appOpts.Get(server.FlagInvCheckPeriod)),
 		ac.encCfg,
-		app.GetEnabledProposals(),
 		appOpts,
 		wasmOpts,
 		baseapp.SetPruning(pruningOpts),
@@ -314,7 +313,6 @@ func (ac appCreator) appExport(
 		homePath,
 		cast.ToUint(appOpts.Get(server.FlagInvCheckPeriod)),
 		ac.encCfg,
-		app.GetEnabledProposals(),
 		appOpts,
 		emptyWasmOpts,
 	)

--- a/e2e/testing/chain.go
+++ b/e2e/testing/chain.go
@@ -98,7 +98,6 @@ func NewTestChain(t *testing.T, chainIdx int, opts ...interface{}) *TestChain {
 		app.DefaultNodeHome,
 		1,
 		encCfg,
-		app.GetEnabledProposals(),
 		app.EmptyBaseAppOptions{},
 		[]wasmkeeper.Option{},
 		baseapp.SetChainID(chainid),

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	cosmossdk.io/math v1.1.2
 	cosmossdk.io/tools/rosetta v0.2.1
 	github.com/CosmWasm/cosmwasm-go v0.5.1-0.20220822092235-974247a04ac7
-	github.com/CosmWasm/wasmd v0.42.0
-	github.com/CosmWasm/wasmvm v1.4.0
+	github.com/CosmWasm/wasmd v0.43.0
+	github.com/CosmWasm/wasmvm v1.4.1
 	github.com/archway-network/voter v0.0.0-00010101000000-000000000000
 	github.com/cometbft/cometbft v0.37.2
 	github.com/cometbft/cometbft-db v0.8.0
@@ -184,7 +184,7 @@ require (
 	pgregory.net/rapid v0.5.5 // indirect
 )
 
-replace github.com/CosmWasm/wasmd => github.com/archway-network/archway-wasmd v0.42.0-archway
+replace github.com/CosmWasm/wasmd => github.com/archway-network/archway-wasmd v0.43.0-archway
 
 replace github.com/archway-network/voter => ./contracts/go/voter
 

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/CosmWasm/cosmwasm-go v0.5.1-0.20220822092235-974247a04ac7 h1:aENjurRl
 github.com/CosmWasm/cosmwasm-go v0.5.1-0.20220822092235-974247a04ac7/go.mod h1:qCTzr8cQYwoYdA9AT4azEVbiYGjULS1nrUgw6YScXks=
 github.com/CosmWasm/tinyjson v0.9.0 h1:sPjgikATp5W0vD/v/Qz99uQ6G/lh/SuK0Wfskqua4Co=
 github.com/CosmWasm/tinyjson v0.9.0/go.mod h1:5+7QnSKrkIWnpIdhUT2t2EYzXnII3/3MlM0oDsBSbc8=
-github.com/CosmWasm/wasmvm v1.4.0 h1:84I3MlvvzcOo2z+ed0ztPi7eeDNk6/sYuK76uyXP1nI=
-github.com/CosmWasm/wasmvm v1.4.0/go.mod h1:vW/E3h8j9xBQs9bCoijDuawKo9kCtxOaS8N8J7KFtkc=
+github.com/CosmWasm/wasmvm v1.4.1 h1:YgodVlBrXa2HJZzOXjWDH0EIRwQzK3zuA73dDPRRLS4=
+github.com/CosmWasm/wasmvm v1.4.1/go.mod h1:fXB+m2gyh4v9839zlIXdMZGeLAxqUdYdFQqYsTha2hc=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
@@ -257,8 +257,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/archway-network/archway-wasmd v0.42.0-archway h1:tDlPUIYh70l6jlt1tY5FD8+mjetju8GIdG1bv7q9C40=
-github.com/archway-network/archway-wasmd v0.42.0-archway/go.mod h1:DiEyBjHxzkEENYqQhHyka+r4HfR72stSPUtGv+Yh/UU=
+github.com/archway-network/archway-wasmd v0.43.0-archway h1:3S5sLGlo99NwIag7NIQGXDfoRhmxZmfh76exQivY3+k=
+github.com/archway-network/archway-wasmd v0.43.0-archway/go.mod h1:gpri8YvkRErBz+qDme5jOThGZmSlHfyN532bWibXOl4=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
- Bumping the wasmd fork to `v0.43.0-archway` https://github.com/archway-network/archway-wasmd/pull/9
- Removing all the wasmd related deprecated proposals as they were removed from the codebase. Should use v1 gov props now for wasmd 


- Updated Dockerfile with relevant wasmvm version. [checksum src](https://github.com/CosmWasm/wasmvm/releases)
