### PR TITLE
chore: v5 release changes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Contains bug fixes.
 Contains all the PRs that improved the code without changing the behaviours.
 -->
 
-## [Unreleased]
+## [v5.0.0]
 
 ### Added
 
@@ -49,11 +49,6 @@ Contains all the PRs that improved the code without changing the behaviours.
 - [#439](https://github.com/archway-network/archway/pull/439) - Renaming `debug` image to `dev`
 - [#461](https://github.com/archway-network/archway/pull/461) - Remove titus network deployment
 
-### Removed
-
-### Fixed
-
-### Improvements
 
 ## [v4.0.2](https://github.com/archway-network/archway/releases/tag/v4.0.2)
 

--- a/app/app_upgrades.go
+++ b/app/app_upgrades.go
@@ -12,7 +12,7 @@ import (
 	upgrade3_0_0 "github.com/archway-network/archway/app/upgrades/3_0_0"
 	upgrade4_0_0 "github.com/archway-network/archway/app/upgrades/4_0_0"
 	upgrade4_0_2 "github.com/archway-network/archway/app/upgrades/4_0_2"
-	upgradelatest "github.com/archway-network/archway/app/upgrades/latest"
+	upgrade5_0_0 "github.com/archway-network/archway/app/upgrades/5_0_0"
 )
 
 // UPGRADES
@@ -24,8 +24,7 @@ var Upgrades = []upgrades.Upgrade{
 	upgrade3_0_0.Upgrade,      // v3.0.0
 	upgrade4_0_0.Upgrade,      // v4.0.0
 	upgrade4_0_2.Upgrade,      // v4.0.2
-
-	upgradelatest.Upgrade, // latest - This upgrade handler is used for all the current changes to the protocol
+	upgrade5_0_0.Upgrade,      // v5.0.0
 }
 
 func (app *ArchwayApp) setupUpgrades() {

--- a/app/upgrades/5_0_0/upgrades.go
+++ b/app/upgrades/5_0_0/upgrades.go
@@ -1,4 +1,4 @@
-package upgradelatest
+package upgrade5_0_0
 
 import (
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
@@ -32,7 +32,7 @@ import (
 
 // This upgrade handler is used for all the current changes to the protocol
 
-const Name = "latest"
+const Name = "v5.0.0"
 
 const NameAsciiArt = `                          
              ###     ###     ### 

--- a/interchaintest/setup.go
+++ b/interchaintest/setup.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	initialVersion = "v4.0.2" // The last release of the chain. The one the mainnet is running on
-	upgradeName    = "latest" // The next upgrade name. Should match the upgrade handler.
+	upgradeName    = "v5.0.0" // The next upgrade name. Should match the upgrade handler.
 	chainName      = "archway"
 )
 

--- a/x/rewards/ante/min_cons_fee_test.go
+++ b/x/rewards/ante/min_cons_fee_test.go
@@ -101,7 +101,8 @@ func TestRewardsMinFeeAnteHandler(t *testing.T) {
 			coin, err := sdk.ParseDecCoin(tc.minPoG)
 			require.NoError(t, err)
 			params.MinPriceOfGas = coin
-			keepers.RewardsKeeper.SetParams(ctx, params)
+			err = keepers.RewardsKeeper.SetParams(ctx, params)
+			require.NoError(t, err)
 
 			// Build transaction
 			txFees, err := sdk.ParseCoinsNormalized(tc.txFees)

--- a/x/rewards/keeper/grpc_query_test.go
+++ b/x/rewards/keeper/grpc_query_test.go
@@ -22,7 +22,8 @@ func (s *KeeperTestSuite) TestGRPC_Params() {
 		MaxWithdrawRecords:    uint64(2),
 		MinPriceOfGas:         rewardsTypes.DefaultMinPriceOfGas,
 	}
-	k.SetParams(ctx, params)
+	err := k.SetParams(ctx, params)
+	s.Assert().NoError(err)
 
 	s.Run("err: empty request", func() {
 		_, err := querySrvr.Params(sdk.WrapSDKContext(ctx), nil)

--- a/x/rewards/keeper/withdraw_test.go
+++ b/x/rewards/keeper/withdraw_test.go
@@ -104,7 +104,8 @@ func (s *KeeperTestSuite) TestWithdrawRewardsByIDs() {
 		ctx := s.chain.GetContext()
 		params := keeper.GetParams(ctx)
 		params.MaxWithdrawRecords = 5
-		keeper.SetParams(ctx, params)
+		err := keeper.SetParams(ctx, params)
+		s.Assert().NoError(err)
 	}
 
 	// Invalid inputs


### PR DESCRIPTION
- Fixing lint where errors were not being checked against in tests
- Renaming upgrade handlers from `latest` to `v5.0.0`
- Update interchaintest version reference for chain upgrade test
- Updating chnagelog