### PR TITLE
chore: Post v5.0.0 release maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,21 @@ Contains bug fixes.
 Contains all the PRs that improved the code without changing the behaviours.
 -->
 
-## [v5.0.0]
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Improvements
+
+## [v5.0.0](https://github.com/archway-network/archway/releases/tag/v5.0.0)
 
 ### Added
 

--- a/app/app_upgrades.go
+++ b/app/app_upgrades.go
@@ -13,6 +13,7 @@ import (
 	upgrade4_0_0 "github.com/archway-network/archway/app/upgrades/4_0_0"
 	upgrade4_0_2 "github.com/archway-network/archway/app/upgrades/4_0_2"
 	upgrade5_0_0 "github.com/archway-network/archway/app/upgrades/5_0_0"
+	upgradelatest "github.com/archway-network/archway/app/upgrades/latest"
 )
 
 // UPGRADES
@@ -25,6 +26,8 @@ var Upgrades = []upgrades.Upgrade{
 	upgrade4_0_0.Upgrade,      // v4.0.0
 	upgrade4_0_2.Upgrade,      // v4.0.2
 	upgrade5_0_0.Upgrade,      // v5.0.0
+
+	upgradelatest.Upgrade, // latest - This upgrade handler is used for all the current changes to the protocol
 }
 
 func (app *ArchwayApp) setupUpgrades() {

--- a/app/upgrades/latest/upgrades.go
+++ b/app/upgrades/latest/upgrades.go
@@ -1,0 +1,32 @@
+package upgradelatest
+
+import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	"github.com/archway-network/archway/app/keepers"
+	"github.com/archway-network/archway/app/upgrades"
+)
+
+// This upgrade handler is used for all the current changes to the protocol
+
+const Name = "latest"
+const NameAsciiArt = ""
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName: Name,
+	CreateUpgradeHandler: func(mm *module.Manager, cfg module.Configurator, keepers keepers.ArchwayKeepers) upgradetypes.UpgradeHandler {
+		return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			migrations, err := mm.RunMigrations(ctx, cfg, fromVM)
+			if err != nil {
+				return nil, err
+			}
+
+			ctx.Logger().Info(upgrades.ArchwayLogo + NameAsciiArt)
+			return migrations, nil
+		}
+	},
+	StoreUpgrades: storetypes.StoreUpgrades{},
+}

--- a/interchaintest/chain_upgrade_test.go
+++ b/interchaintest/chain_upgrade_test.go
@@ -97,7 +97,6 @@ func fundChainUser(t *testing.T, ctx context.Context, archwayChain *cosmos.Cosmo
 func startChain(t *testing.T, startingVersion string) (*cosmos.CosmosChain, *client.Client, context.Context) {
 	numOfVals := 1
 	archwayChainSpec := GetArchwaySpec(initialVersion, numOfVals)
-	archwayChainSpec.UsingNewGenesisCommand = false
 	archwayChainSpec.ChainConfig.ModifyGenesis = cosmos.ModifyGenesis(getTestGenesis())
 	cf := interchaintest.NewBuiltinChainFactory(zaptest.NewLogger(t), []*interchaintest.ChainSpec{
 		archwayChainSpec,

--- a/interchaintest/chain_upgrade_test.go
+++ b/interchaintest/chain_upgrade_test.go
@@ -2,9 +2,11 @@ package interchaintest
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
+	cosmosproto "github.com/cosmos/gogoproto/proto"
 	"github.com/docker/docker/client"
 	interchaintest "github.com/strangelove-ventures/interchaintest/v7"
 	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
@@ -12,6 +14,8 @@ import (
 	"github.com/strangelove-ventures/interchaintest/v7/testutil"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
+
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
 
 const (
@@ -69,15 +73,44 @@ func submitUpgradeProposalAndVote(t *testing.T, ctx context.Context, nextUpgrade
 
 	haltHeight := height + haltHeightDelta // The height at which upgrade should be applied
 
-	proposal := cosmos.SoftwareUpgradeProposal{
-		Deposit:     "10000000000" + archwayChain.Config().Denom,
-		Title:       "Test upgrade",
-		Name:        nextUpgradeName,
-		Description: "Every PR we perform a upgrade check to ensure nothing breaks",
-		Height:      haltHeight,
+	govAuthorityAddr := ""
+	cmd := []string{
+		"archwayd", "q", "auth", "module-account", "gov",
+		"--node", archwayChain.GetRPCAddress(),
+		"--home", archwayChain.HomeDir(),
+		"--chain-id", archwayChain.Config().ChainID,
+		"--output", "json",
+	}
+	stdout, _, err := archwayChain.Exec(ctx, cmd, nil)
+	require.NoError(t, err, "could not query the gov module account")
+
+	queryRes := ModuleAccountQueryResponse{}
+	err = json.Unmarshal(stdout, &queryRes)
+	require.NoError(t, err, "could not parse the response")
+
+	if queryRes.Account.Name == "gov" {
+		govAuthorityAddr = queryRes.Account.BaseAccount.Address
+	} else {
+		t.Fatal("could not find the gov module account")
 	}
 
-	upgradeTx, err := archwayChain.UpgradeProposal(ctx, chainUser.KeyName(), proposal) // Submitting the software upgrade proposal
+	proposalMsg := upgradetypes.MsgSoftwareUpgrade{
+		Authority: govAuthorityAddr,
+		Plan: upgradetypes.Plan{
+			Name:   nextUpgradeName,
+			Height: int64(haltHeight),
+		},
+	}
+
+	proposal, err := archwayChain.BuildProposal([]cosmosproto.Message{&proposalMsg},
+		"Test Upgrade",
+		"Every PR we preform an upgrade check to ensure nothing breaks",
+		"metadata",
+		"10000000000"+archwayChain.Config().Denom,
+	)
+	require.NoError(t, err, "error building proposal tx")
+
+	upgradeTx, err := archwayChain.SubmitProposal(ctx, chainUser.KeyName(), proposal) // Submitting the software upgrade proposal
 	require.NoError(t, err, "error submitting software upgrade proposal tx")
 
 	err = archwayChain.VoteOnProposalAllValidators(ctx, upgradeTx.ProposalID, cosmos.ProposalVoteYes)
@@ -118,4 +151,20 @@ func startChain(t *testing.T, startingVersion string) (*cosmos.CosmosChain, *cli
 		_ = ic.Close()
 	})
 	return archwayChain, client, ctx
+}
+
+type ModuleAccountQueryResponse struct {
+	Account ModuleAccountData `json:"account"`
+}
+
+type ModuleAccountData struct {
+	BaseAccount BaseAccountData `json:"base_account"`
+	Name        string          `json:"name"`
+}
+
+type BaseAccountData struct {
+	AccountNumber string `json:"account_number"`
+	Address       string `json:"address"`
+	PubKey        string `json:"pub_key"`
+	Sequence      string `json:"sequence"`
 }

--- a/interchaintest/setup.go
+++ b/interchaintest/setup.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	initialVersion = "v4.0.2" // The last release of the chain. The one the mainnet is running on
-	upgradeName    = "v5.0.0" // The next upgrade name. Should match the upgrade handler.
+	initialVersion = "v5.0.0" // The last release of the chain. The one the mainnet is running on
+	upgradeName    = "latest" // The next upgrade name. Should match the upgrade handler.
 	chainName      = "archway"
 )
 

--- a/interchaintest/setup.go
+++ b/interchaintest/setup.go
@@ -79,32 +79,12 @@ const (
 func getTestGenesis() []cosmos.GenesisKV {
 	return []cosmos.GenesisKV{
 		{
-			Key:   "app_state.gov.voting_params.voting_period",
+			Key:   "app_state.gov.params.voting_period",
 			Value: votingPeriod,
 		},
 		{
-			Key:   "app_state.gov.deposit_params.max_deposit_period",
+			Key:   "app_state.gov.params.max_deposit_period",
 			Value: maxDepositPeriod,
-		},
-		{
-			Key:   "app_state.gov.deposit_params.min_deposit.0.denom",
-			Value: denom,
-		},
-		{
-			Key:   "app_state.mint.params.mint_denom",
-			Value: denom,
-		},
-		{
-			Key:   "app_state.rewards.params.min_price_of_gas.denom",
-			Value: denom,
-		},
-		{
-			Key:   "app_state.rewards.min_consensus_fee.denom",
-			Value: denom,
-		},
-		{
-			Key:   "app_state.staking.params.bond_denom",
-			Value: denom,
 		},
 	}
 }


### PR DESCRIPTION
- adding new upgrade handler
- updating versions in interchaintest
- updating changelog

- updating the software upgrade prop in chainupgradetest to be x/gov v1
- removing the custom denom config for interchaintest genesis as the framework takes care of it