### PR TITLE
Replacing v5.0.0 upgrade handler with v5.0.2

### DIFF
--- a/.github/workflows/interchaintest.yaml
+++ b/.github/workflows/interchaintest.yaml
@@ -4,6 +4,7 @@ on:
     pull_request:
         branches: 
             - main
+            - 'releases/**'
 
 jobs:
     build_images:

--- a/app/app_upgrades.go
+++ b/app/app_upgrades.go
@@ -12,7 +12,7 @@ import (
 	upgrade3_0_0 "github.com/archway-network/archway/app/upgrades/3_0_0"
 	upgrade4_0_0 "github.com/archway-network/archway/app/upgrades/4_0_0"
 	upgrade4_0_2 "github.com/archway-network/archway/app/upgrades/4_0_2"
-	upgrade5_0_0 "github.com/archway-network/archway/app/upgrades/5_0_0"
+	upgrade5_0_2 "github.com/archway-network/archway/app/upgrades/5_0_2"
 )
 
 // UPGRADES
@@ -24,7 +24,7 @@ var Upgrades = []upgrades.Upgrade{
 	upgrade3_0_0.Upgrade,      // v3.0.0
 	upgrade4_0_0.Upgrade,      // v4.0.0
 	upgrade4_0_2.Upgrade,      // v4.0.2
-	upgrade5_0_0.Upgrade,      // v5.0.0
+	upgrade5_0_2.Upgrade,      // v5.0.2
 }
 
 func (app *ArchwayApp) setupUpgrades() {

--- a/app/upgrades/5_0_2/upgrades.go
+++ b/app/upgrades/5_0_2/upgrades.go
@@ -1,4 +1,4 @@
-package upgrade5_0_0
+package upgrade5_0_2
 
 import (
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
@@ -32,13 +32,13 @@ import (
 
 // This upgrade handler is used for all the current changes to the protocol
 
-const Name = "v5.0.0"
+const Name = "v5.0.2"
 
 const NameAsciiArt = `                          
              ###     ###     ### 
-     # #     #       # #     # #    
-     # #     ###     # #     # #   
-      #        #     # #     # # 
+     # #     #       # #       #    
+     # #     ###     # #     ###   
+      #        #     # #     #  
              ###  #  ###  #  ### 
 
 `

--- a/interchaintest/setup.go
+++ b/interchaintest/setup.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	initialVersion = "v4.0.2" // The last release of the chain. The one the mainnet is running on
-	upgradeName    = "v5.0.0" // The next upgrade name. Should match the upgrade handler.
+	upgradeName    = "v5.0.2" // The next upgrade name. Should match the upgrade handler.
 	chainName      = "archway"
 )
 


### PR DESCRIPTION
- Replace v5.0.0 upgrade handler with v5.0.2
- Update the interchaintests workflows to run on release branches too 