### PR TITLE
feat(x/callback): Implement the callback execution 

### DIFF
--- a/x/callback/abci.go
+++ b/x/callback/abci.go
@@ -1,0 +1,66 @@
+package callback
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cometbft/cometbft/libs/log"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/archway-network/archway/x/callback/keeper"
+	"github.com/archway-network/archway/x/callback/types"
+)
+
+// EndBlocker fetches all the callbacks registered for the current block height and executes them
+func EndBlocker(ctx sdk.Context, k keeper.Keeper, wk types.WasmKeeperExpected) []abci.ValidatorUpdate {
+	logger := k.Logger(ctx)
+	currentHeight := ctx.BlockHeight()
+	callbacks, err := k.GetCallbacksByHeight(ctx, currentHeight)
+	if err != nil {
+		panic(err)
+	}
+	params, err := k.Params.Get(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, callback := range callbacks {
+		callbackMsg := types.NewCallbackMsg(callback.GetJobId())
+		defer recoverAnyPanics(logger, callback)()
+		logger.Debug("contract callbacks", "contract_address", callback.ContractAddress, "job_id", callback.GetJobId())
+
+		childCtx, commit := ctx.WithGasMeter(sdk.NewGasMeter(params.GetCallbackGasLimit())).CacheContext()
+
+		if _, err := wk.Sudo(childCtx, sdk.MustAccAddressFromBech32(callback.ContractAddress), callbackMsg.Bytes()); err != nil {
+			logger.Error("error executing callback", "contract_address", callback.ContractAddress, "job_id", callback.GetJobId(), "error", err)
+		}
+
+		ctx.EventManager().EmitEvents(childCtx.EventManager().Events())
+		commit()
+	}
+
+	return nil
+}
+
+// recoverAnyPanics catches any panics and logs cause to error
+func recoverAnyPanics(logger log.Logger, callback types.Callback) func() {
+	return func() {
+		if r := recover(); r != nil {
+			var cause string
+			switch rType := r.(type) {
+			case sdk.ErrorOutOfGas:
+				cause = fmt.Sprintf("out of gas in location: %v", rType.Descriptor)
+			default:
+				cause = fmt.Sprintf("%s", r)
+			}
+			logger.
+				Error("panic executing callback",
+					"contract-address", callback.GetContractAddress(),
+					"job_id", callback.GetJobId(),
+					"cause", cause,
+					"stacktrace", string(debug.Stack()),
+				)
+		}
+	}
+}

--- a/x/callback/abci.go
+++ b/x/callback/abci.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"runtime/debug"
 
+	"cosmossdk.io/collections"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/libs/log"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -15,29 +16,37 @@ import (
 // EndBlocker fetches all the callbacks registered for the current block height and executes them
 func EndBlocker(ctx sdk.Context, k keeper.Keeper, wk types.WasmKeeperExpected) []abci.ValidatorUpdate {
 	logger := k.Logger(ctx)
-	currentHeight := ctx.BlockHeight()
-	callbacks, err := k.GetCallbacksByHeight(ctx, currentHeight)
-	if err != nil {
-		panic(err)
-	}
 	params, err := k.Params.Get(ctx)
 	if err != nil {
 		panic(err)
 	}
 
+	currentHeight := ctx.BlockHeight()
+	// fetching all callbacks for current height
+	callbacks, err := k.GetCallbacksByHeight(ctx, currentHeight)
+	if err != nil {
+		panic(err)
+	}
+
 	for _, callback := range callbacks {
+		// creating CallbackMsg which is encoded to json and passed as input to contract execution
 		callbackMsg := types.NewCallbackMsg(callback.GetJobId())
+		// handling any panics
 		defer recoverAnyPanics(logger, callback)()
 		logger.Debug("contract callbacks", "contract_address", callback.ContractAddress, "job_id", callback.GetJobId())
 
+		// creating a chiled context with limited gas meter based on configured params
 		childCtx, commit := ctx.WithGasMeter(sdk.NewGasMeter(params.GetCallbackGasLimit())).CacheContext()
 
+		// executing the callback on the contract
 		if _, err := wk.Sudo(childCtx, sdk.MustAccAddressFromBech32(callback.ContractAddress), callbackMsg.Bytes()); err != nil {
 			logger.Error("error executing callback", "contract_address", callback.ContractAddress, "job_id", callback.GetJobId(), "error", err)
 		}
 
-		ctx.EventManager().EmitEvents(childCtx.EventManager().Events())
 		commit()
+
+		// deleting the callback after execution
+		k.Callbacks.Remove(ctx, collections.Join3(currentHeight, sdk.MustAccAddressFromBech32(callback.ContractAddress).Bytes(), callback.GetJobId()))
 	}
 
 	return nil
@@ -56,7 +65,7 @@ func recoverAnyPanics(logger log.Logger, callback types.Callback) func() {
 			}
 			logger.
 				Error("panic executing callback",
-					"contract-address", callback.GetContractAddress(),
+					"contract_address", callback.GetContractAddress(),
 					"job_id", callback.GetJobId(),
 					"cause", cause,
 					"stacktrace", string(debug.Stack()),

--- a/x/callback/module.go
+++ b/x/callback/module.go
@@ -80,14 +80,16 @@ func (a AppModuleBasic) GetQueryCmd() *cobra.Command {
 type AppModule struct {
 	AppModuleBasic
 
-	keeper keeper.Keeper
+	keeper     keeper.Keeper
+	wasmKeeper types.WasmKeeperExpected
 }
 
 // NewAppModule creates a new AppModule object.
-func NewAppModule(cdc codec.Codec, keeper keeper.Keeper) AppModule {
+func NewAppModule(cdc codec.Codec, keeper keeper.Keeper, wk types.WasmKeeperExpected) AppModule {
 	return AppModule{
 		AppModuleBasic: AppModuleBasic{cdc: cdc},
 		keeper:         keeper,
+		wasmKeeper:     wk,
 	}
 }
 
@@ -127,5 +129,5 @@ func (a AppModule) BeginBlock(ctx sdk.Context, block abci.RequestBeginBlock) {}
 
 // EndBlock returns the end blocker for the module. It returns no validator updates.
 func (a AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
-	return []abci.ValidatorUpdate{}
+	return EndBlocker(ctx, a.keeper, a.wasmKeeper)
 }

--- a/x/callback/types/expected_keepers.go
+++ b/x/callback/types/expected_keepers.go
@@ -11,6 +11,7 @@ import (
 type WasmKeeperExpected interface {
 	HasContractInfo(ctx sdk.Context, contractAddress sdk.AccAddress) bool
 	GetContractInfo(ctx sdk.Context, contractAddress sdk.AccAddress) *wasmdtypes.ContractInfo
+	Sudo(ctx sdk.Context, contractAddress sdk.AccAddress, msg []byte) ([]byte, error)
 }
 
 type RewardsKeeperExpected interface {

--- a/x/callback/types/sudo_msg.go
+++ b/x/callback/types/sudo_msg.go
@@ -3,12 +3,15 @@ package types
 import "encoding/json"
 
 // SudoMsg callback message sent to a contract.
+// This is encoded as JSON input to the contract when executing the callback
 type SudoMsg struct {
+	// Callback is the endpoint name at the contract which is called
 	Callback *CallbackMsg `json:"callback,omitempty"`
 }
 
-// CallbackMsg
+// CallbackMsg is the callback message sent to a contract.
 type CallbackMsg struct {
+	// JobID is the user specified job id
 	JobID uint64 `json:"job_id"`
 }
 
@@ -21,6 +24,7 @@ func NewCallbackMsg(jobID uint64) SudoMsg {
 	}
 }
 
+// Bytes returns the callback message as JSON bytes
 func (s SudoMsg) Bytes() []byte {
 	msgBz, err := json.Marshal(s)
 	if err != nil {
@@ -29,6 +33,7 @@ func (s SudoMsg) Bytes() []byte {
 	return msgBz
 }
 
+// String returns the callback message as JSON string
 func (s SudoMsg) String() string {
 	return string(s.Bytes())
 }

--- a/x/callback/types/sudo_msg.go
+++ b/x/callback/types/sudo_msg.go
@@ -1,0 +1,34 @@
+package types
+
+import "encoding/json"
+
+// SudoMsg callback message sent to a contract.
+type SudoMsg struct {
+	Callback *CallbackMsg `json:"callback,omitempty"`
+}
+
+// CallbackMsg
+type CallbackMsg struct {
+	JobID uint64 `json:"job_id"`
+}
+
+// NewCallback creates a new Callback instance.
+func NewCallbackMsg(jobID uint64) SudoMsg {
+	return SudoMsg{
+		Callback: &CallbackMsg{
+			JobID: jobID,
+		},
+	}
+}
+
+func (s SudoMsg) Bytes() []byte {
+	msgBz, err := json.Marshal(s)
+	if err != nil {
+		panic(err)
+	}
+	return msgBz
+}
+
+func (s SudoMsg) String() string {
+	return string(s.Bytes())
+}


### PR DESCRIPTION
- On endblocker, generate the input msg to be passed to the contract `{"callback": {"job_id": 2}}`
- On completion, delete the callback and all its info from state
- In case of error, log the error with callback details
- In case of panic, recover and log with the callback details