### PR TITLE
feat(x/callback): Handle fees

### DIFF
--- a/x/callback/abci.go
+++ b/x/callback/abci.go
@@ -62,7 +62,7 @@ func callbackExec(ctx sdk.Context, k keeper.Keeper, wk types.WasmKeeperExpected,
 		txFeesConsumed := k.CalculateTransactionFees(ctx, gasUsed)
 		if txFeesConsumed.IsLT(*callback.FeeSplit.TransactionFees) {
 			refundAmount := callback.FeeSplit.TransactionFees.Sub(txFeesConsumed)
-			err := k.SendFromCallbackModule(ctx, callback.ReservedBy, refundAmount)
+			err := k.RefundFromCallbackModule(ctx, callback.ReservedBy, refundAmount)
 			if err != nil {
 				panic(err)
 			}

--- a/x/callback/keeper/fees.go
+++ b/x/callback/keeper/fees.go
@@ -40,7 +40,12 @@ func (k Keeper) EstimateCallbackFees(ctx sdk.Context, blockHeight int64) (sdk.Co
 	blockReservationFee := sdk.NewCoin(sdk.DefaultBondDenom, blockReservationFeesAmount.RoundInt())
 
 	// Calculates the fees based on the max gas limit of the callback and current price of gas
-	transactionFeeAmount := k.rewardsKeeper.ComputationalPriceOfGas(ctx).Amount.MulInt64(int64(params.GetCallbackGasLimit()))
-	transactionFee := sdk.NewCoin(sdk.DefaultBondDenom, transactionFeeAmount.RoundInt())
+	transactionFee := k.CalculateTransactionFees(ctx, params.GetCallbackGasLimit())
 	return futureReservationFee, blockReservationFee, transactionFee, nil
+}
+
+func (k Keeper) CalculateTransactionFees(ctx sdk.Context, gasAmount uint64) sdk.Coin {
+	transactionFeeAmount := k.rewardsKeeper.ComputationalPriceOfGas(ctx).Amount.MulInt64(int64(gasAmount))
+	transactionFee := sdk.NewCoin(sdk.DefaultBondDenom, transactionFeeAmount.RoundInt())
+	return transactionFee
 }

--- a/x/callback/keeper/keeper.go
+++ b/x/callback/keeper/keeper.go
@@ -80,8 +80,8 @@ func (k Keeper) SendToCallbackModule(ctx sdk.Context, sender string, amount sdk.
 	return k.bankKeeper.SendCoinsFromAccountToModule(ctx, senderAddr, types.ModuleName, sdk.NewCoins(amount))
 }
 
-// SendFromCallbackModule sends coins from the x/callback module account to the recipient.
-func (k Keeper) SendFromCallbackModule(ctx sdk.Context, recipient string, amount sdk.Coin) error {
+// RefundFromCallbackModule sends coins from the x/callback module account to the recipient.
+func (k Keeper) RefundFromCallbackModule(ctx sdk.Context, recipient string, amount sdk.Coin) error {
 	recipientAddr, err := sdk.AccAddressFromBech32(recipient)
 	if err != nil {
 		return err

--- a/x/callback/keeper/keeper.go
+++ b/x/callback/keeper/keeper.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authTypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 	"github.com/archway-network/archway/internal/collcompat"
 	"github.com/archway-network/archway/x/callback/types"
@@ -68,4 +69,27 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 // GetAuthority returns the x/callback module's authority.
 func (k Keeper) GetAuthority() string {
 	return k.authority
+}
+
+// SendToCallbackModule sends coins from the sender to the x/callback module account.
+func (k Keeper) SendToCallbackModule(ctx sdk.Context, sender string, amount sdk.Coin) error {
+	senderAddr, err := sdk.AccAddressFromBech32(sender)
+	if err != nil {
+		return err
+	}
+	return k.bankKeeper.SendCoinsFromAccountToModule(ctx, senderAddr, types.ModuleName, sdk.NewCoins(amount))
+}
+
+// SendFromCallbackModule sends coins from the x/callback module account to the recipient.
+func (k Keeper) SendFromCallbackModule(ctx sdk.Context, recipient string, amount sdk.Coin) error {
+	recipientAddr, err := sdk.AccAddressFromBech32(recipient)
+	if err != nil {
+		return err
+	}
+	return k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, recipientAddr, sdk.NewCoins(amount))
+}
+
+// SendToFeeCollector sends coins from the x/callback module account to the fee collector account.
+func (k Keeper) SendToFeeCollector(ctx sdk.Context, amount sdk.Coin) error {
+	return k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, authTypes.FeeCollectorName, sdk.NewCoins(amount))
 }

--- a/x/callback/keeper/msg_server.go
+++ b/x/callback/keeper/msg_server.go
@@ -96,10 +96,11 @@ func (s MsgServer) RequestCallback(c context.Context, request *types.MsgRequestC
 	}
 
 	// Send the fees into module account
-	err = s.keeper.bankKeeper.SendCoinsFromAccountToModule(ctx, sdk.MustAccAddressFromBech32(request.Sender), types.ModuleName, sdk.NewCoins(request.GetFees()))
+	err = s.keeper.SendToCallbackModule(ctx, request.Sender, request.GetFees())
 	if err != nil {
 		return nil, err
 	}
+
 	return &types.MsgRequestCallbackResponse{}, nil
 }
 

--- a/x/callback/keeper/msg_server.go
+++ b/x/callback/keeper/msg_server.go
@@ -47,7 +47,7 @@ func (s MsgServer) CancelCallback(c context.Context, request *types.MsgCancelCal
 
 	// Returning the transaction fees + surplus fees as the callback was never executed
 	refundFees := callback.FeeSplit.TransactionFees.Add(*callback.FeeSplit.SurplusFees)
-	err = s.keeper.SendFromCallbackModule(ctx, request.Sender, refundFees)
+	err = s.keeper.RefundFromCallbackModule(ctx, request.Sender, refundFees)
 	if err != nil {
 		return nil, err
 	}

--- a/x/callback/types/expected_keepers.go
+++ b/x/callback/types/expected_keepers.go
@@ -22,4 +22,5 @@ type RewardsKeeperExpected interface {
 type BankKeeperExpected interface {
 	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
+	SendCoinsFromModuleToModule(ctx sdk.Context, senderModule, recipientModule string, amt sdk.Coins) error
 }


### PR DESCRIPTION
Handling fees in the following way for the following events
      
1. CancelCallback
   `transactionFee` - Refund completely
   `futureReservationFee` - Send to FeeCollector
   `blockReservationFee` - Send to FeeCollector
   `surplusFees` - Refund completely

2. ExecuteCallback
   `transactionFee` - Calculate the amount of gas consumed and the total tx fees for that amount of gas. If the tx fees is lesser than what was paid, refund the rest to the address who reserved the callback. Send the tx fees to fee_collector.
   `futureReservationFee` - Send to FeeCollector
   `blockReservationFee` - Send to FeeCollector
   `surplusFees` - Send to FeeCollector