### PR TITLE
ci: Generate swagger files for each release

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -29,6 +29,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Generate swagger file
+        run: make proto-swagger-gen
+
       - name: Login to GHCR
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Generate swagger file
+        run: make proto-swagger-gen
+
       - name: ${{ matrix.release }}
         run: make ${{ matrix.release }}
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Contains all the PRs that improved the code without changing the behaviors.
 
 - [#505](https://github.com/archway-network/archway/pull/505) - Update release process to account for release candidates on Titus
 - [#507](https://github.com/archway-network/archway/pull/507) – Version bump wasmd to v0.45.0 and cosmos-sdk to v0.47.6
+- [#528](https://github.com/archway-network/archway/pull/528) – Generate swagger files for each release
 
 ### Deprecated
 


### PR DESCRIPTION
To ensure the swagger file is upto date, before each release of the image, generate the swagger file so that the most recent swagger contents are included in the binary.