### PR TITLE
ci: fixing interchaintest issue with rc tags

### DIFF
--- a/.github/workflows/interchaintest.yaml
+++ b/.github/workflows/interchaintest.yaml
@@ -21,7 +21,8 @@ jobs:
               id: lastrelease
               uses: revam/gh-action-get-tag-and-version@v1
               with:
-                suffixRegex: "-rc[0-9]+"
+                suffix: "-rc."
+                suffixRegex: "(-rc\\.\\d+)?"
 
             - name: Checkout heighliner
               uses: actions/checkout@v3

--- a/.github/workflows/interchaintest.yaml
+++ b/.github/workflows/interchaintest.yaml
@@ -90,7 +90,9 @@ jobs:
 
             - name: Get last release tag
               id: lastrelease
-              uses: revam/gh-action-get-tag-and-version@v1
+              uses: WyriHaximus/github-action-get-previous-tag@v1
+              with:
+                prefix: 'v'
 
             - name: Download ${{ steps.lastrelease.outputs.tag }} image
               uses: actions/download-artifact@v3

--- a/.github/workflows/interchaintest.yaml
+++ b/.github/workflows/interchaintest.yaml
@@ -20,6 +20,8 @@ jobs:
             - name: Get last release tag
               id: lastrelease
               uses: revam/gh-action-get-tag-and-version@v1
+              with:
+                suffixRegex: "-rc[0-9]+"
 
             - name: Checkout heighliner
               uses: actions/checkout@v3

--- a/.github/workflows/interchaintest.yaml
+++ b/.github/workflows/interchaintest.yaml
@@ -19,10 +19,9 @@ jobs:
 
             - name: Get last release tag
               id: lastrelease
-              uses: revam/gh-action-get-tag-and-version@v1
+              uses: WyriHaximus/github-action-get-previous-tag@v1
               with:
-                suffix: "-rc."
-                suffixRegex: "(-rc\\.\\d+)?"
+                prefix: 'v'
 
             - name: Checkout heighliner
               uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Contains all the PRs that improved the code without changing the behaviors.
 - [#476](https://github.com/archway-network/archway/pull/476) - Fix amd64 binary compatibility on newer linux OS
 - [#514](https://github.com/archway-network/archway/pull/514) - Fix snapshot db being hardcoded from goleveldb to based on config 
 - [#522](https://github.com/archway-network/archway/pull/522) - Fix Archway module endpoints not showing up in swagger
+- [#538](https://github.com/archway-network/archway/pull/538) - Fix Archway module endpoints not showing up in swagger
 
 ### Improvements
 

--- a/interchaintest/setup.go
+++ b/interchaintest/setup.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	initialVersion = "v5.0.2" // The last release of the chain. The one the mainnet is running on
-	upgradeName    = "latest" // The next upgrade name. Should match the upgrade handler.
+	initialVersion = "v6.0.0-rc.4" // The last release of the chain. The one the mainnet is running on
+	upgradeName    = "latest"      // The next upgrade name. Should match the upgrade handler.
 	chainName      = "archway"
 )
 


### PR DESCRIPTION
The previous gh action used did not detect release candidate tags. Which would cause issues in PRs.
Replacing with a better one.