### PR TITLE
fix: fixing wrong bond denom being considered for callback fees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Contains all the PRs that improved the code without changing the behaviors.
 - [#538](https://github.com/archway-network/archway/pull/538) - Fixing the interchain test gh workflow failing cuz rc tags were not recognized 
 - [#539](https://github.com/archway-network/archway/pull/539) - Remediations for x/callback audit
 - [#552](https://github.com/archway-network/archway/pull/552) - Fix issue with x/callback callback error code was not identified correctly when setting cwerrors
+- [#559](https://github.com/archway-network/archway/pull/559) - Fixing wrong bond denom being considered for x/callback and x/cwerrors fees
 
 
 ## [v6.0.0](https://github.com/archway-network/archway/releases/tag/v6.0.0)

--- a/app/upgrades/7_0_0/upgrades.go
+++ b/app/upgrades/7_0_0/upgrades.go
@@ -38,6 +38,7 @@ var Upgrade = upgrades.Upgrade{
 			}
 
 			ctx.Logger().Info("Setting default params for the new modules")
+			bondDenom := keepers.StakingKeeper.BondDenom(ctx)
 			// Setting callback params
 			callbackParams, err := keepers.CallbackKeeper.GetParams(ctx)
 			if err != nil {
@@ -58,9 +59,9 @@ var Upgrade = upgrades.Upgrade{
 			if err != nil {
 				return nil, err
 			}
-			cwerrorsParams.ErrorStoredTime = 302400                                                      // roughly 21 days
-			cwerrorsParams.SubscriptionFee = sdk.NewInt64Coin(sdk.DefaultBondDenom, 1000000000000000000) // 1 ARCH (1e18 attoarch)
-			cwerrorsParams.SubscriptionPeriod = 302400                                                   // roughly 21 days
+			cwerrorsParams.ErrorStoredTime = 302400                                           // roughly 21 days
+			cwerrorsParams.SubscriptionFee = sdk.NewInt64Coin(bondDenom, 1000000000000000000) // 1 ARCH (1e18 attoarch)
+			cwerrorsParams.SubscriptionPeriod = 302400                                        // roughly 21 days
 			err = keepers.CWErrorsKeeper.SetParams(ctx, cwerrorsParams)
 			if err != nil {
 				return nil, err

--- a/x/callback/types/msg.go
+++ b/x/callback/types/msg.go
@@ -46,9 +46,6 @@ func (m MsgRequestCallback) ValidateBasic() error {
 	if _, err := sdk.AccAddressFromBech32(m.ContractAddress); err != nil {
 		return errorsmod.Wrapf(sdkErrors.ErrInvalidAddress, "invalid contract address: %v", err)
 	}
-	if m.Fees.Denom != sdk.DefaultBondDenom {
-		return errorsmod.Wrapf(sdkErrors.ErrInvalidCoins, "invalid fees denom: %v", m.Fees.Denom)
-	}
 
 	return nil
 }


### PR DESCRIPTION
- removing the use of sdk.DefaultBondDenom as its not set accurately on titus and results in bad config