### PR TITLE
fix(x/cwerrors): send fees from the sender account instead of contract account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Contains all the PRs that improved the code without changing the behaviors.
 - [#539](https://github.com/archway-network/archway/pull/539) - Remediations for x/callback audit
 - [#552](https://github.com/archway-network/archway/pull/552) - Fix issue with x/callback callback error code was not identified correctly when setting cwerrors
 - [#559](https://github.com/archway-network/archway/pull/559) - Fixing wrong bond denom being considered for x/callback and x/cwerrors fees
+- [#562](https://github.com/archway-network/archway/pull/562) - Fixing the account from which x/cwerrors subscription fees are deducted
 
 
 ## [v6.0.0](https://github.com/archway-network/archway/releases/tag/v6.0.0)

--- a/x/cwerrors/keeper/msg_server_test.go
+++ b/x/cwerrors/keeper/msg_server_test.go
@@ -90,7 +90,7 @@ func (s *KeeperTestSuite) TestSubscribeToError() {
 			testCase: "FAIL: account doesnt have enough balance",
 			input: func() *types.MsgSubscribeToError {
 				return &types.MsgSubscribeToError{
-					Sender:          contractAdminAcc.Address.String(),
+					Sender:          contractAddr.String(),
 					ContractAddress: contractAddr.String(),
 					Fee:             sdk.NewInt64Coin(sdk.DefaultBondDenom, 101),
 				}

--- a/x/cwerrors/keeper/subscriptions.go
+++ b/x/cwerrors/keeper/subscriptions.go
@@ -33,7 +33,7 @@ func (k Keeper) SetSubscription(ctx sdk.Context, sender, contractAddress sdk.Acc
 	if fee.IsLT(params.SubscriptionFee) {
 		return -1, types.ErrInsufficientSubscriptionFee
 	}
-	err = k.bankKeeper.SendCoinsFromAccountToModule(ctx, contractAddress, authtypes.FeeCollectorName, sdk.NewCoins(fee))
+	err = k.bankKeeper.SendCoinsFromAccountToModule(ctx, sender, authtypes.FeeCollectorName, sdk.NewCoins(fee))
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
when cwerrors subscription was being set, the fees was deducted from the contract account instead of the sender address