### PR TITLE
refactor(x/callback): Remove redundant code in SaveCallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Contains all the PRs that improved the code without changing the behaviors.
 ### Fixed
 
 ### Improvements
+- [#567](https://github.com/archway-network/archway/pull/567) - Remove redundant params fetching in SaveCallback 
 
 ## [v7.0.0](https://github.com/archway-network/archway/releases/tag/v7.0.0)
 

--- a/x/callback/keeper/callback.go
+++ b/x/callback/keeper/callback.go
@@ -118,10 +118,6 @@ func (k Keeper) SaveCallback(ctx sdk.Context, callback types.Callback) error {
 	// This is to ensure that if the param value is decreased in the future, before the callback is executed,
 	// it does not fail with "out of gas" error. it wouldnt be fair for the contract to err out of the callback
 	// if it wouldnt have been expected to at the time of registration
-	params, err = k.GetParams(ctx)
-	if err != nil {
-		return err
-	}
 	callback.MaxGasLimit = params.CallbackGasLimit
 
 	return k.Callbacks.Set(ctx, collections.Join3(callback.CallbackHeight, contractAddress.Bytes(), callback.JobId), callback)


### PR DESCRIPTION
Params were being fetched two times in same func. Removed the second time