### PR TITLE
ci(proto): automatically publish proto files

### DIFF
--- a/.github/workflows/proto-registry.yaml
+++ b/.github/workflows/proto-registry.yaml
@@ -1,0 +1,20 @@
+name: Buf-Push
+# Protobuf runs buf (https://buf.build/) push updated proto files to https://buf.build/cosmos/cosmos-sdk
+# This workflow is only run when a .proto file has been changed
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "proto/**"
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: bufbuild/buf-setup-action@v1.21.0
+      - uses: bufbuild/buf-push-action@v1
+        with:
+          input: "proto"
+          buf_token: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/proto-registry.yaml
+++ b/.github/workflows/proto-registry.yaml
@@ -1,10 +1,10 @@
-name: Buf-Push
+name: Publish to Buf Schema Registry
 # Protobuf runs buf (https://buf.build/) push updated proto files to https://buf.build/cosmos/cosmos-sdk
 # This workflow is only run when a .proto file has been changed
 on:
   push:
-    branches:
-      - main
+    branches: [main]
+    tags: [v*]
     paths:
       - "proto/**"
 
@@ -12,9 +12,9 @@ jobs:
   push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: bufbuild/buf-setup-action@v1.21.0
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-setup-action@v1
       - uses: bufbuild/buf-push-action@v1
         with:
-          input: "proto"
+          input: proto
           buf_token: ${{ secrets.BUF_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Contains all the PRs that improved the code without changing the behaviors.
 ## [Unreleased]
 
 ### Added
+- [#571](https://github.com/archway-network/archway/pull/571) - Automatically
+publish proto files to buf.build
 
 ### Changed
 


### PR DESCRIPTION
Automatically publish the protocol's ProtoBuf files to the [Buf Schema Registry](https://buf.build/archway-network/archway)