### PR TITLE
ci(proto): use buf 1.31 to push files

### DIFF
--- a/.github/workflows/proto-registry.yaml
+++ b/.github/workflows/proto-registry.yaml
@@ -8,7 +8,6 @@ on:
     paths:
       - proto/**
   pull_request:
-    types: [opened, reopened]
     paths:
       - proto/**
       - .github/workflows/proto-registry.yaml

--- a/.github/workflows/proto-registry.yaml
+++ b/.github/workflows/proto-registry.yaml
@@ -18,7 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-setup-action@v1.32
+      - uses: bufbuild/buf-setup-action@v1.32.0
+      - uses: bufbuild/buf-lint-action@v1
+        with:
+          input: proto
       - uses: bufbuild/buf-push-action@v1
         with:
           input: proto

--- a/.github/workflows/proto-registry.yaml
+++ b/.github/workflows/proto-registry.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-setup-action@v1.32.0
+      - uses: bufbuild/buf-setup-action@v1.31.0
       - uses: bufbuild/buf-lint-action@v1
         with:
           input: proto

--- a/.github/workflows/proto-registry.yaml
+++ b/.github/workflows/proto-registry.yaml
@@ -18,9 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: bufbuild/buf-setup-action@v1.31.0
-      - uses: bufbuild/buf-lint-action@v1
-        with:
-          input: proto
       - uses: bufbuild/buf-push-action@v1
         with:
           input: proto

--- a/.github/workflows/proto-registry.yaml
+++ b/.github/workflows/proto-registry.yaml
@@ -6,15 +6,21 @@ on:
     branches: [main]
     tags: [v*]
     paths:
-      - "proto/**"
+      - proto/**
+  pull_request:
+    types: [opened, reopened]
+    paths:
+      - proto/**
+      - .github/workflows/proto-registry.yaml
 
 jobs:
   push:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-setup-action@v1.32
       - uses: bufbuild/buf-push-action@v1
         with:
           input: proto
+          draft: ${{ github.ref_name != 'main'}}
           buf_token: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/proto-registry.yaml
+++ b/.github/workflows/proto-registry.yaml
@@ -7,10 +7,6 @@ on:
     tags: [v*]
     paths:
       - proto/**
-  pull_request:
-    paths:
-      - proto/**
-      - .github/workflows/proto-registry.yaml
 
 jobs:
   push:
@@ -21,5 +17,4 @@ jobs:
       - uses: bufbuild/buf-push-action@v1
         with:
           input: proto
-          draft: ${{ github.ref_name != 'main'}}
           buf_token: ${{ secrets.BUF_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,22 +30,26 @@ Contains all the PRs that improved the code without changing the behaviors.
 
 ## [Unreleased]
 
-### Added
+### Fixed
+
 - [#571](https://github.com/archway-network/archway/pull/571) - Automatically
 publish proto files to buf.build
 
-### Changed
+## [v7.0.1](https://github.com/archway-network/archway/releases/tag/v7.0.1)
 
-### Deprecated
+### Added
 
-### Removed
+- [#571](https://github.com/archway-network/archway/pull/571) - Automatically
+publish proto files to buf.build
 
 ### Fixed
+
 - [#568](https://github.com/archway-network/archway/pull/568) - Update Swagger doc and config to include CWICA and CWErrors modules
 - [#570](https://github.com/archway-network/archway/pull/570) - Fix the Docker.deprecated file to build  
 - [#569](https://github.com/archway-network/archway/pull/569) - Audit remidiations for x/cwerrors and x/cwica 
 
 ### Improvements
+
 - [#567](https://github.com/archway-network/archway/pull/567) - Remove redundant params fetching in SaveCallback 
 
 ## [v7.0.0](https://github.com/archway-network/archway/releases/tag/v7.0.0)


### PR DESCRIPTION
The `buf` CLI v1.32 seems to have an undocumented breaking change and won't accept the `buf.yaml` file structure defined on `v1`.

This is possibly a bug on their side since it's [mentioned in the changelog](https://github.com/bufbuild/buf/releases/tag/v1.32.0) that the CLI is backwards compatible with `v1` projects.