### PR TITLE
fix: Update cometbft module replacement in go.mod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Contains bug fixes.
 Contains all the PRs that improved the code without changing the behaviors.
 -->
 
-## Un-Released
+## [v10.1.1](https://github.com/archway-network/archway/releases/tag/v10.1.1)
 
 ### Added
 - [#604](https://github.com/archway-network/archway/pull/604) - Move Dockerfile.deprecated -> Dockerfile.legacy and update wasmvm versions. Dockerfile.legacy will be maintained due to existing demand

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ Contains all the PRs that improved the code without changing the behaviors.
 ### Added
 - [#604](https://github.com/archway-network/archway/pull/604) - Move Dockerfile.deprecated -> Dockerfile.legacy and update wasmvm versions. Dockerfile.legacy will be maintained due to existing demand
 
+### Changed
+- [#606](https://github.com/archway-network/archway/pull/606) - Update cometbft version to patch
+
+
 ## [v10.1.0](https://github.com/archway-network/archway/releases/tag/v10.1.0)
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -222,4 +222,4 @@ replace github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.2021
 
 replace github.com/spf13/viper => github.com/spf13/viper v1.17.0
 
-replace github.com/cometbft/cometbft => github.com/archway-network/cometbft-sec-tachyon v0.38.x-tachyon-fix
+replace github.com/cometbft/cometbft => github.com/archway-network/cometbft-sec-tachyon-2 v0.38.x-tachyon-fix

--- a/go.mod
+++ b/go.mod
@@ -221,3 +221,5 @@ replace github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.8.1
 replace github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 
 replace github.com/spf13/viper => github.com/spf13/viper v1.17.0
+
+replace github.com/cometbft/cometbft => github.com/archway-network/cometbft-sec-tachyon v0.38.x-tachyon-fix


### PR DESCRIPTION
Replaces github.com/cometbft/cometbft with github.com/archway-network/cometbft-sec-tachyon v0.38.x-tachyon-fix in interchaintest/go.mod to use a custom fork or patched version.